### PR TITLE
feat: add Zod input validation

### DIFF
--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -6,6 +6,7 @@ import { formatOutput, companyToRow, safeJSON } from '../format'
 import { resolveCompany } from '../resolve'
 import { upsertSearchIndex, removeSearchIndex } from '../db'
 import { runHook } from '../hooks'
+import { companyAddSchema, companyEditSchema, formatZodError } from '../schema'
 
 export function registerCompanyCommands(program: Command) {
   const cmd = program.command('company').description('Manage companies')
@@ -18,25 +19,31 @@ export function registerCompanyCommands(program: Command) {
     .option('--set <kv>', 'Custom field', collect, [])
     .action((opts) => {
       const { db, config } = getCtx()
+
+      // Validate and transform inputs via Zod
+      const parsed = companyAddSchema(config.phone.default_country).safeParse(opts)
+      if (!parsed.success) {
+        const firstIssue = parsed.error.issues[0]
+        if (firstIssue.path[0] === 'phone') {
+          die(`Error: invalid phone — ${firstIssue.message}`)
+        }
+        die(`Error: ${formatZodError(parsed.error)}`)
+      }
+      const data = parsed.data
+
       const cid = makeId('co')
       const n = now()
-      const websites: string[] = []
-      for (const w of opts.website) {
-        const norm = normalizeWebsite(w)
+      const websites = data.website
+      for (const norm of websites) {
         checkDupeWebsite(db, norm)
-        websites.push(norm)
       }
-      const phones: string[] = []
-      for (const p of opts.phone) {
-        try {
-          const norm = normalizePhone(p, config.phone.default_country)
-          checkDupePhone(db, norm, 'companies')
-          phones.push(norm)
-        } catch (e: any) { die(`Error: invalid phone — ${e.message}`) }
+      const phones = data.phone
+      for (const norm of phones) {
+        checkDupePhone(db, norm, 'companies')
       }
-      const custom = parseKV(opts.set)
+      const custom = parseKV(data.set)
       db.run('INSERT INTO companies (id,name,websites,phones,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?)',
-        [cid, opts.name, JSON.stringify(websites), JSON.stringify(phones), JSON.stringify(opts.tag), JSON.stringify(custom), n, n])
+        [cid, data.name, JSON.stringify(websites), JSON.stringify(phones), JSON.stringify(data.tag), JSON.stringify(custom), n, n])
       const row = db.query('SELECT * FROM companies WHERE id = ?').get(cid)
       upsertSearchIndex(db, 'company', cid, buildCompanySearch(row))
       console.log(cid)
@@ -77,22 +84,26 @@ export function registerCompanyCommands(program: Command) {
       const { db, config } = getCtx()
       const co = resolveCompany(db, ref, config)
       if (!co) die(`Error: company not found: ${ref}`)
+
+      // Validate and transform edit inputs via Zod
+      const parsed = companyEditSchema(config.phone.default_country).safeParse(opts)
+      if (!parsed.success) die(`Error: ${formatZodError(parsed.error)}`)
+      const data = parsed.data
+
       let websites: string[] = safeJSON(co.websites)
       let phones: string[] = safeJSON(co.phones)
       let tags: string[] = safeJSON(co.tags)
       let custom: Record<string, any> = safeJSON(co.custom_fields)
       let name = co.name
-      if (opts.name) name = opts.name
-      for (const w of opts.addWebsite) {
-        const norm = normalizeWebsite(w)
-        if (websites.includes(norm)) die(`Error: duplicate website "${w}" — already on this company`)
+      if (data.name) name = data.name
+      for (const norm of data.addWebsite) {
+        if (websites.includes(norm)) die(`Error: duplicate website "${norm}" — already on this company`)
         checkDupeWebsite(db, norm, co.id)
         websites.push(norm)
       }
       for (const w of opts.rmWebsite) { const norm = normalizeWebsite(w); websites = websites.filter(v => v !== norm) }
-      for (const p of opts.addPhone) {
-        const norm = normalizePhone(p, config.phone.default_country)
-        if (phones.includes(norm)) die(`Error: duplicate phone "${p}" — already on this company`)
+      for (const norm of data.addPhone) {
+        if (phones.includes(norm)) die(`Error: duplicate phone "${norm}" — already on this company`)
         checkDupePhone(db, norm, 'companies', co.id)
         phones.push(norm)
       }
@@ -100,11 +111,11 @@ export function registerCompanyCommands(program: Command) {
         const norm = tryNormalizePhone(p, config.phone.default_country)
         phones = norm ? phones.filter(v => v !== norm) : phones.filter(v => v !== p)
       }
-      for (const t of opts.addTag) { if (!tags.includes(t)) tags.push(t) }
-      for (const t of opts.rmTag) tags = tags.filter(v => v !== t)
-      const kvs = parseKV(opts.set)
+      for (const t of data.addTag) { if (!tags.includes(t)) tags.push(t) }
+      for (const t of data.rmTag) tags = tags.filter(v => v !== t)
+      const kvs = parseKV(data.set)
       for (const [k, v] of Object.entries(kvs)) custom[k] = v
-      for (const k of opts.unset) delete custom[k]
+      for (const k of data.unset) delete custom[k]
       db.run('UPDATE companies SET name=?,websites=?,phones=?,tags=?,custom_fields=?,updated_at=? WHERE id=?',
         [name, JSON.stringify(websites), JSON.stringify(phones), JSON.stringify(tags), JSON.stringify(custom), now(), co.id])
       const row = db.query('SELECT * FROM companies WHERE id = ?').get(co.id)

--- a/src/commands/contact.ts
+++ b/src/commands/contact.ts
@@ -7,6 +7,7 @@ import { resolveContact } from '../resolve'
 import { upsertSearchIndex, removeSearchIndex } from '../db'
 import { parseFilter, applyFilter } from '../filter'
 import { runHook } from '../hooks'
+import { contactAddSchema, contactEditSchema, formatZodError } from '../schema'
 
 export function registerContactCommands(program: Command) {
   const cmd = program.command('contact').description('Manage contacts')
@@ -24,34 +25,43 @@ export function registerContactCommands(program: Command) {
     .option('--set <kv>', 'Custom field', collect, [])
     .action((opts) => {
       const { db, config } = getCtx()
+
+      // Validate and transform inputs via Zod
+      const parsed = contactAddSchema(config.phone.default_country).safeParse(opts)
+      if (!parsed.success) {
+        const firstIssue = parsed.error.issues[0]
+        // Preserve existing error message patterns for phone validation
+        if (firstIssue.path[0] === 'phone') {
+          die(`Error: invalid phone — ${firstIssue.message}`)
+        }
+        die(`Error: ${formatZodError(parsed.error)}`)
+      }
+      const data = parsed.data
+
       const cid = makeId('ct')
       const n = now()
-      for (const e of opts.email) checkDupeEmail(db, e)
-      const phones: string[] = []
-      for (const p of opts.phone) {
-        try {
-          const norm = normalizePhone(p, config.phone.default_country)
-          checkDupePhone(db, norm, 'contacts')
-          phones.push(norm)
-        } catch (e: any) { die(`Error: invalid phone — ${e.message}`) }
+      for (const e of data.email) checkDupeEmail(db, e)
+      const phones = data.phone
+      for (const norm of phones) {
+        checkDupePhone(db, norm, 'contacts')
       }
-      const linkedin = opts.linkedin ? normalizeSocialHandle('linkedin', opts.linkedin) : null
-      const x = opts.x ? normalizeSocialHandle('x', opts.x) : null
-      const bluesky = opts.bluesky ? normalizeSocialHandle('bluesky', opts.bluesky) : null
-      const telegram = opts.telegram ? normalizeSocialHandle('telegram', opts.telegram) : null
+      const linkedin = data.linkedin ?? null
+      const x = data.x ?? null
+      const bluesky = data.bluesky ?? null
+      const telegram = data.telegram ?? null
       if (linkedin) checkDupeSocial(db, 'linkedin', linkedin)
       if (x) checkDupeSocial(db, 'x', x)
       if (bluesky) checkDupeSocial(db, 'bluesky', bluesky)
       if (telegram) checkDupeSocial(db, 'telegram', telegram)
       const companies: string[] = []
-      for (const c of opts.company) companies.push(getOrCreateCompany(db, c, config))
-      const custom = parseKV(opts.set)
+      for (const c of data.company) companies.push(getOrCreateCompany(db, c, config))
+      const custom = parseKV(data.set)
       db.run('INSERT INTO contacts (id,name,emails,phones,companies,linkedin,x,bluesky,telegram,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
-        [cid, opts.name, JSON.stringify(opts.email), JSON.stringify(phones), JSON.stringify(companies),
-         linkedin, x, bluesky, telegram, JSON.stringify(opts.tag), JSON.stringify(custom), n, n])
+        [cid, data.name, JSON.stringify(data.email), JSON.stringify(phones), JSON.stringify(companies),
+         linkedin, x, bluesky, telegram, JSON.stringify(data.tag), JSON.stringify(custom), n, n])
       const row = db.query('SELECT * FROM contacts WHERE id = ?').get(cid)
       upsertSearchIndex(db, 'contact', cid, buildContactSearch(row))
-      runHook(config, 'post-contact-add', { id: cid, name: opts.name, emails: opts.email, phones, companies, linkedin, x, bluesky, telegram, tags: opts.tag, custom_fields: custom })
+      runHook(config, 'post-contact-add', { id: cid, name: data.name, emails: data.email, phones, companies, linkedin, x, bluesky, telegram, tags: data.tag, custom_fields: custom })
       console.log(cid)
     })
 
@@ -101,18 +111,23 @@ export function registerContactCommands(program: Command) {
       const { db, config } = getCtx()
       const c = resolveContact(db, ref, config)
       if (!c) die(`Error: contact not found: ${ref}`)
+
+      // Validate and transform edit inputs via Zod
+      const parsed = contactEditSchema(config.phone.default_country).safeParse(opts)
+      if (!parsed.success) die(`Error: ${formatZodError(parsed.error)}`)
+      const data = parsed.data
+
       let emails: string[] = safeJSON(c.emails)
       let phones: string[] = safeJSON(c.phones)
       let companies: string[] = safeJSON(c.companies)
       let tags: string[] = safeJSON(c.tags)
       let custom: Record<string, any> = safeJSON(c.custom_fields)
       let name = c.name, linkedin = c.linkedin, x = c.x, bluesky = c.bluesky, telegram = c.telegram
-      if (opts.name) name = opts.name
-      for (const e of opts.addEmail) { checkDupeEmail(db, e, c.id); if (!emails.includes(e)) emails.push(e) }
-      for (const e of opts.rmEmail) emails = emails.filter(v => v !== e)
-      for (const p of opts.addPhone) {
-        const norm = normalizePhone(p, config.phone.default_country)
-        if (phones.includes(norm)) die(`Error: duplicate phone "${p}" — already on this contact`)
+      if (data.name) name = data.name
+      for (const e of data.addEmail) { checkDupeEmail(db, e, c.id); if (!emails.includes(e)) emails.push(e) }
+      for (const e of data.rmEmail) emails = emails.filter(v => v !== e)
+      for (const norm of data.addPhone) {
+        if (phones.includes(norm)) die(`Error: duplicate phone "${norm}" — already on this contact`)
         checkDupePhone(db, norm, 'contacts', c.id)
         phones.push(norm)
       }
@@ -120,17 +135,17 @@ export function registerContactCommands(program: Command) {
         const norm = tryNormalizePhone(p, config.phone.default_country)
         phones = norm ? phones.filter(v => v !== norm) : phones.filter(v => v !== p)
       }
-      for (const co of opts.addCompany) { const n = getOrCreateCompany(db, co, config); if (!companies.includes(n)) companies.push(n) }
-      for (const co of opts.rmCompany) companies = companies.filter(v => v !== co)
-      for (const t of opts.addTag) { if (!tags.includes(t)) tags.push(t) }
-      for (const t of opts.rmTag) tags = tags.filter(v => v !== t)
-      if (opts.linkedin) linkedin = normalizeSocialHandle('linkedin', opts.linkedin)
-      if (opts.x) x = normalizeSocialHandle('x', opts.x)
-      if (opts.bluesky) bluesky = normalizeSocialHandle('bluesky', opts.bluesky)
-      if (opts.telegram) telegram = normalizeSocialHandle('telegram', opts.telegram)
-      const kvs = parseKV(opts.set)
+      for (const co of data.addCompany) { const n = getOrCreateCompany(db, co, config); if (!companies.includes(n)) companies.push(n) }
+      for (const co of data.rmCompany) companies = companies.filter(v => v !== co)
+      for (const t of data.addTag) { if (!tags.includes(t)) tags.push(t) }
+      for (const t of data.rmTag) tags = tags.filter(v => v !== t)
+      if (data.linkedin) linkedin = data.linkedin
+      if (data.x) x = data.x
+      if (data.bluesky) bluesky = data.bluesky
+      if (data.telegram) telegram = data.telegram
+      const kvs = parseKV(data.set)
       for (const [k, v] of Object.entries(kvs)) custom[k] = v
-      for (const k of opts.unset) {
+      for (const k of data.unset) {
         delete custom[k]
         if (k === 'linkedin') linkedin = null
         if (k === 'x') x = null

--- a/src/commands/deal.ts
+++ b/src/commands/deal.ts
@@ -4,6 +4,7 @@ import { resolveContact, resolveCompanyForLink, resolveDeal } from '../resolve'
 import { formatOutput, dealToRow, safeJSON } from '../format'
 import { upsertSearchIndex, removeSearchIndex } from '../db'
 import { runHook } from '../hooks'
+import { dealAddSchema, dealEditSchema, formatZodError } from '../schema'
 
 export function registerDealCommands(program: Command) {
   const cmd = program.command('deal').description('Manage deals')
@@ -20,41 +21,46 @@ export function registerDealCommands(program: Command) {
     .option('--set <kv>', 'Custom field', collect, [])
     .action((opts) => {
       const { db, config } = getCtx()
+
+      // Validate and transform inputs via Zod
+      const parsed = dealAddSchema(config.pipeline.stages).safeParse(opts)
+      if (!parsed.success) {
+        const firstIssue = parsed.error.issues[0]
+        const path = firstIssue.path[0] as string
+        // Preserve existing error message patterns
+        if (path === 'value') die('Error: value must be non-negative')
+        if (path === 'probability') die('Error: probability must be between 0 and 100')
+        if (path === 'expectedClose') die('Error: invalid expected-close date')
+        if (path === 'stage') die(`Error: invalid stage "${opts.stage}"`)
+        die(`Error: ${formatZodError(parsed.error)}`)
+      }
+      const data = parsed.data
+
       const id = makeId('dl')
       const n = now()
-      if (opts.value !== undefined && Number(opts.value) < 0) die('Error: value must be non-negative')
-      if (opts.probability !== undefined) {
-        const prob = Number(opts.probability)
-        if (prob < 0 || prob > 100) die('Error: probability must be between 0 and 100')
-      }
-      if (opts.expectedClose) {
-        const d = new Date(opts.expectedClose)
-        if (isNaN(d.getTime())) die('Error: invalid expected-close date')
-      }
-      const stage = opts.stage || config.pipeline.stages[0]
-      if (!config.pipeline.stages.includes(stage)) die(`Error: invalid stage "${stage}"`)
+      const stage = data.stage || config.pipeline.stages[0]
       const contactIds: string[] = []
-      for (const ref of opts.contact) {
+      for (const ref of data.contact) {
         const ct = resolveContact(db, ref, config)
         if (!ct) die(`Error: contact not found: ${ref}`)
         contactIds.push(ct.id)
       }
       let companyId: string | null = null
-      if (opts.company) {
-        const co = resolveCompanyForLink(db, opts.company, config)
+      if (data.company) {
+        const co = resolveCompanyForLink(db, data.company, config)
         if (co) {
           companyId = co.id
         } else {
           // Auto-create only for plain names (no dots suggesting domain)
-          if (opts.company.includes('.')) die(`Error: company not found: ${opts.company}`)
-          companyId = getOrCreateCompanyId(db, opts.company, config)
+          if (data.company.includes('.')) die(`Error: company not found: ${data.company}`)
+          companyId = getOrCreateCompanyId(db, data.company, config)
         }
       }
-      const custom = parseKV(opts.set)
-      const value = opts.value !== undefined ? Number(opts.value) : null
-      const probability = opts.probability !== undefined ? Number(opts.probability) : null
+      const custom = parseKV(data.set)
+      const value = data.value !== undefined ? data.value : null
+      const probability = data.probability !== undefined ? data.probability : null
       db.run('INSERT INTO deals (id,title,value,stage,contacts,company,expected_close,probability,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
-        [id, opts.title, value, stage, JSON.stringify(contactIds), companyId, opts.expectedClose || null, probability, JSON.stringify(opts.tag), JSON.stringify(custom), n, n])
+        [id, data.title, value, stage, JSON.stringify(contactIds), companyId, data.expectedClose || null, probability, JSON.stringify(data.tag), JSON.stringify(custom), n, n])
       const row = db.query('SELECT * FROM deals WHERE id = ?').get(id)
       upsertSearchIndex(db, 'deal', id, buildDealSearch(row))
       console.log(id)
@@ -109,25 +115,31 @@ export function registerDealCommands(program: Command) {
       const { db, config } = getCtx()
       const d = resolveDeal(db, ref)
       if (!d) die(`Error: deal not found: ${ref}`)
-      const title = opts.title ?? d.title
-      const value = opts.value !== undefined ? Number(opts.value) : d.value
+
+      // Validate edit inputs via Zod
+      const parsed = dealEditSchema.safeParse(opts)
+      if (!parsed.success) die(`Error: ${formatZodError(parsed.error)}`)
+      const data = parsed.data
+
+      const title = data.title ?? d.title
+      const value = data.value !== undefined ? data.value : d.value
       let contacts: string[] = safeJSON(d.contacts)
       let tags: string[] = safeJSON(d.tags)
       let custom: Record<string, any> = safeJSON(d.custom_fields)
-      for (const r of opts.addContact) {
+      for (const r of data.addContact) {
         const ct = resolveContact(db, r, config)
         if (!ct) die(`Error: contact not found: ${r}`)
         if (!contacts.includes(ct.id)) contacts.push(ct.id)
       }
-      for (const r of opts.rmContact) {
+      for (const r of data.rmContact) {
         const ct = resolveContact(db, r, config)
         if (ct) contacts = contacts.filter(id => id !== ct.id)
       }
-      for (const t of opts.addTag) { if (!tags.includes(t)) tags.push(t) }
-      for (const t of opts.rmTag) tags = tags.filter(v => v !== t)
-      const kvs = parseKV(opts.set)
+      for (const t of data.addTag) { if (!tags.includes(t)) tags.push(t) }
+      for (const t of data.rmTag) tags = tags.filter(v => v !== t)
+      const kvs = parseKV(data.set)
       for (const [k, v] of Object.entries(kvs)) custom[k] = v
-      for (const k of opts.unset) delete custom[k]
+      for (const k of data.unset) delete custom[k]
       db.run('UPDATE deals SET title=?,value=?,contacts=?,tags=?,custom_fields=?,updated_at=? WHERE id=?',
         [title, value, JSON.stringify(contacts), JSON.stringify(tags), JSON.stringify(custom), now(), d.id])
       const row = db.query('SELECT * FROM deals WHERE id = ?').get(d.id)

--- a/src/commands/importexport.ts
+++ b/src/commands/importexport.ts
@@ -5,6 +5,7 @@ import { resolveContact, resolveCompany } from '../resolve'
 import { formatOutput, contactToRow, companyToRow, dealToRow, activityToRow, safeJSON } from '../format'
 import { upsertSearchIndex } from '../db'
 import { tryNormalizePhone, normalizeWebsite } from '../normalize'
+import { importContactRowSchema, importCompanyRowSchema, importDealRowSchema } from '../schema'
 
 const CONTACT_FIELDS = new Set(['name', 'email', 'emails', 'phone', 'phones', 'company', 'companies', 'tags', 'linkedin', 'x', 'bluesky', 'telegram'])
 const COMPANY_FIELDS = new Set(['name', 'website', 'websites', 'phone', 'phones', 'tags'])
@@ -20,7 +21,8 @@ export function registerImportExportCommands(program: Command) {
       let imported = 0, skipped = 0, errors = 0
       for (const rec of records) {
         try {
-          if (!rec.name) { if (opts.skipErrors) { errors++; continue }; die('Error: row missing name') }
+          const rowParsed = importContactRowSchema.safeParse(rec)
+          if (!rowParsed.success) { if (opts.skipErrors) { errors++; continue }; die('Error: row missing name') }
           const name = rec.name || ''
           const emails = splitField(rec.email || rec.emails)
           const phones = splitField(rec.phone || rec.phones).map(p => {
@@ -76,7 +78,8 @@ export function registerImportExportCommands(program: Command) {
       let imported = 0
       for (const rec of records) {
         try {
-          if (!rec.name) { if (opts.skipErrors) continue; die('Error: company missing name') }
+          const rowParsed = importCompanyRowSchema.safeParse(rec)
+          if (!rowParsed.success) { if (opts.skipErrors) continue; die('Error: company missing name') }
           const websites = splitField(rec.website || rec.websites).map(w => {
             try { return normalizeWebsite(w) } catch { return w }
           })
@@ -112,7 +115,8 @@ export function registerImportExportCommands(program: Command) {
       let imported = 0
       for (const rec of records) {
         try {
-          if (!rec.title) { if (opts.skipErrors) continue; die('Error: deal missing title') }
+          const rowParsed = importDealRowSchema.safeParse(rec)
+          if (!rowParsed.success) { if (opts.skipErrors) continue; die('Error: deal missing title') }
           const stage = rec.stage || config.pipeline.stages[0]
           const value = rec.value ? Number(rec.value) : null
           const tags = splitField(rec.tags)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod'
+import { normalizePhone, normalizeWebsite, normalizeSocialHandle } from './normalize'
+
+// ── Reusable transforms ──
+
+/** Zod transform that normalizes a phone string via libphonenumber-js. */
+export const phoneTransform = (defaultCountry?: string) =>
+  z.string().transform((val, ctx) => {
+    try {
+      return normalizePhone(val, defaultCountry)
+    } catch (e: any) {
+      ctx.addIssue({ code: 'custom', message: e.message })
+      return val
+    }
+  })
+
+/** Zod transform that normalizes a website URL. */
+export const websiteTransform = z.string().transform((val, ctx) => {
+  try {
+    return normalizeWebsite(val)
+  } catch (e: any) {
+    ctx.addIssue({ code: 'custom', message: `Invalid website: ${val}` })
+    return val
+  }
+})
+
+/** Zod transform for social handles. */
+export const socialHandleSchema = (platform: string) =>
+  z.string().transform(val => normalizeSocialHandle(platform, val))
+
+// ── Contact schemas ──
+
+export const contactAddSchema = (defaultCountry?: string) =>
+  z.object({
+    name: z.string().min(1, 'Contact name is required'),
+    email: z.array(z.string().email('Invalid email format')).default([]),
+    phone: z.array(phoneTransform(defaultCountry)).default([]),
+    company: z.array(z.string()).default([]),
+    tag: z.array(z.string()).default([]),
+    linkedin: z.string().transform(val => normalizeSocialHandle('linkedin', val)).optional(),
+    x: z.string().transform(val => normalizeSocialHandle('x', val)).optional(),
+    bluesky: z.string().transform(val => normalizeSocialHandle('bluesky', val)).optional(),
+    telegram: z.string().transform(val => normalizeSocialHandle('telegram', val)).optional(),
+    set: z.array(z.string()).default([]),
+  })
+
+export const contactEditSchema = (defaultCountry?: string) =>
+  z.object({
+    name: z.string().min(1).optional(),
+    addEmail: z.array(z.string().email('Invalid email format')).default([]),
+    rmEmail: z.array(z.string()).default([]),
+    addPhone: z.array(phoneTransform(defaultCountry)).default([]),
+    rmPhone: z.array(z.string()).default([]),
+    addCompany: z.array(z.string()).default([]),
+    rmCompany: z.array(z.string()).default([]),
+    addTag: z.array(z.string()).default([]),
+    rmTag: z.array(z.string()).default([]),
+    linkedin: z.string().transform(val => normalizeSocialHandle('linkedin', val)).optional(),
+    x: z.string().transform(val => normalizeSocialHandle('x', val)).optional(),
+    bluesky: z.string().transform(val => normalizeSocialHandle('bluesky', val)).optional(),
+    telegram: z.string().transform(val => normalizeSocialHandle('telegram', val)).optional(),
+    set: z.array(z.string()).default([]),
+    unset: z.array(z.string()).default([]),
+  })
+
+// ── Company schemas ──
+
+export const companyAddSchema = (defaultCountry?: string) =>
+  z.object({
+    name: z.string().min(1, 'Company name is required'),
+    website: z.array(websiteTransform).default([]),
+    phone: z.array(phoneTransform(defaultCountry)).default([]),
+    tag: z.array(z.string()).default([]),
+    set: z.array(z.string()).default([]),
+  })
+
+export const companyEditSchema = (defaultCountry?: string) =>
+  z.object({
+    name: z.string().min(1).optional(),
+    addWebsite: z.array(websiteTransform).default([]),
+    rmWebsite: z.array(z.string()).default([]),
+    addPhone: z.array(phoneTransform(defaultCountry)).default([]),
+    rmPhone: z.array(z.string()).default([]),
+    addTag: z.array(z.string()).default([]),
+    rmTag: z.array(z.string()).default([]),
+    set: z.array(z.string()).default([]),
+    unset: z.array(z.string()).default([]),
+  })
+
+// ── Deal schemas ──
+
+export const dealAddSchema = (validStages: string[]) =>
+  z.object({
+    title: z.string().min(1, 'Deal title is required'),
+    value: z.string().transform(Number).pipe(z.number().nonnegative('Value must be non-negative')).optional(),
+    stage: z.string().refine(s => validStages.includes(s), s => ({ message: `Invalid stage "${s}"` })).optional(),
+    contact: z.array(z.string()).default([]),
+    company: z.string().optional(),
+    expectedClose: z.string().refine(s => !isNaN(new Date(s).getTime()), 'Invalid expected-close date').optional(),
+    probability: z.string().transform(Number).pipe(z.number().min(0).max(100, 'Probability must be between 0 and 100')).optional(),
+    tag: z.array(z.string()).default([]),
+    set: z.array(z.string()).default([]),
+  })
+
+export const dealEditSchema = z.object({
+  title: z.string().min(1).optional(),
+  value: z.string().transform(Number).pipe(z.number().nonnegative('Value must be non-negative')).optional(),
+  addContact: z.array(z.string()).default([]),
+  rmContact: z.array(z.string()).default([]),
+  addTag: z.array(z.string()).default([]),
+  rmTag: z.array(z.string()).default([]),
+  set: z.array(z.string()).default([]),
+  unset: z.array(z.string()).default([]),
+})
+
+// ── Import row schemas ──
+
+export const importContactRowSchema = z.object({
+  name: z.string().min(1, 'Row missing name'),
+}).passthrough()
+
+export const importCompanyRowSchema = z.object({
+  name: z.string().min(1, 'Company missing name'),
+}).passthrough()
+
+export const importDealRowSchema = z.object({
+  title: z.string().min(1, 'Deal missing title'),
+}).passthrough()
+
+// ── Config file schema ──
+
+export const configSchema = z.object({
+  database: z.object({ path: z.string() }).optional(),
+  pipeline: z.object({ stages: z.array(z.string().min(1)) }).optional(),
+  defaults: z.object({ format: z.enum(['table', 'json', 'csv']) }).optional(),
+  phone: z.object({
+    default_country: z.string().max(2).optional(),
+    display: z.enum(['e164', 'international', 'national']).optional(),
+  }).optional(),
+  search: z.object({ model: z.string() }).optional(),
+  hooks: z.record(z.string(), z.string()).optional(),
+  mount: z.object({
+    default_path: z.string().optional(),
+    readonly: z.boolean().optional(),
+    max_recent_activity: z.number().int().positive().optional(),
+    search_limit: z.number().int().positive().optional(),
+  }).optional(),
+}).passthrough()
+
+// ── Helper to format Zod errors for CLI output ──
+
+export function formatZodError(error: z.ZodError): string {
+  return error.issues.map(issue => {
+    const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+    return `${path}${issue.message}`
+  }).join('; ')
+}


### PR DESCRIPTION
## Summary
- Add `src/schema.ts` with Zod schemas for validating CLI inputs at the boundary: contact add/edit, company add/edit, deal add/edit, and import row validation
- Update `src/commands/contact.ts`, `company.ts`, `deal.ts`, and `importexport.ts` to parse inputs through Zod schemas using `safeParse` before processing
- Phone normalization, website normalization, and social handle extraction are implemented as Zod transforms, replacing inline try/catch and manual validation
- Config file schema and reusable validation primitives (email, phone, website transforms) defined for future use
- All 341 existing tests pass with no changes to test files

## Test plan
- [x] Run `bun test` — all 341 tests pass (0 failures)
- [x] Verified error messages preserved for: invalid phone, duplicate email/phone/website, invalid stage, negative value, invalid probability, missing name/title
- [x] Verified phone/website/social normalization transforms produce same output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)