### PR TITLE
refactor: migrate to Drizzle ORM + libSQL

### DIFF
--- a/src/commands/activity.ts
+++ b/src/commands/activity.ts
@@ -1,8 +1,10 @@
+import { eq, sql } from 'drizzle-orm'
 import type { Command } from 'commander'
 import { getCtx, makeId, now, die, collect, parseKV } from '../lib/helpers'
 import { resolveEntity, resolveContact, resolveCompany, resolveDeal } from '../resolve'
 import { formatOutput, activityToRow, safeJSON } from '../format'
 import { upsertSearchIndex } from '../db'
+import * as schema from '../drizzle-schema'
 
 const VALID_TYPES = ['note', 'call', 'meeting', 'email']
 
@@ -15,10 +17,10 @@ export function registerLogCommand(program: Command) {
     .option('--deal <id>', 'Link to deal')
     .option('--at <date>', 'Custom timestamp')
     .option('--set <kv>', 'Custom field', collect, [])
-    .action((type, ref, body, opts) => {
-      const { db, config } = getCtx()
+    .action(async (type, ref, body, opts) => {
+      const { db, config } = await getCtx()
       if (!VALID_TYPES.includes(type)) die(`Error: invalid activity type "${type}". Must be one of: ${VALID_TYPES.join(', ')}`)
-      const resolved = resolveEntity(db, ref, config)
+      const resolved = await resolveEntity(db, ref, config)
       if (!resolved) die(`Error: entity not found: ${ref}`)
       const id = makeId('ac')
       const ts = opts.at || now()
@@ -30,9 +32,10 @@ export function registerLogCommand(program: Command) {
       else if (resolved.type === 'company') company = resolved.entity.id
       else if (resolved.type === 'deal') deal = resolved.entity.id
       if (opts.deal) deal = opts.deal
-      db.run('INSERT INTO activities (id,type,body,contact,company,deal,custom_fields,created_at) VALUES (?,?,?,?,?,?,?,?)',
-        [id, type, body, contact, company, deal, JSON.stringify(custom), ts])
-      upsertSearchIndex(db, 'activity', id, `${type} ${body}`)
+      await db.insert(schema.activities).values({
+        id, type, body, contact, company, deal, custom_fields: JSON.stringify(custom), created_at: ts
+      })
+      await upsertSearchIndex(db, 'activity', id, `${type} ${body}`)
     })
 }
 
@@ -45,16 +48,16 @@ export function registerActivityCommands(program: Command) {
     .option('--type <type>')
     .option('--since <date>')
     .option('--limit <n>')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let rows = (db.query('SELECT * FROM activities').all() as any[]).map(a => activityToRow(a))
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let rows = (await db.select().from(schema.activities)).map(a => activityToRow(a))
       if (opts.contact) {
-        const ct = resolveContact(db, opts.contact, config)
+        const ct = await resolveContact(db, opts.contact, config)
         if (ct) rows = rows.filter(a => a.contact === ct.id)
         else rows = []
       }
       if (opts.company) {
-        const co = resolveCompany(db, opts.company, config)
+        const co = await resolveCompany(db, opts.company, config)
         if (co) rows = rows.filter(a => a.company === co.id)
         else rows = []
       }

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -1,3 +1,4 @@
+import { eq, sql } from 'drizzle-orm'
 import type { Command } from 'commander'
 import { getCtx, makeId, now, die, collect, parseKV, checkDupePhone, checkDupeWebsite,
   buildCompanySearch, companyDetail, showEntity } from '../lib/helpers'
@@ -6,6 +7,7 @@ import { formatOutput, companyToRow, safeJSON } from '../format'
 import { resolveCompany } from '../resolve'
 import { upsertSearchIndex, removeSearchIndex } from '../db'
 import { runHook } from '../hooks'
+import * as schema from '../drizzle-schema'
 
 export function registerCompanyCommands(program: Command) {
   const cmd = program.command('company').description('Manage companies')
@@ -16,29 +18,32 @@ export function registerCompanyCommands(program: Command) {
     .option('--phone <phone>', 'Phone', collect, [])
     .option('--tag <tag>', 'Tag', collect, [])
     .option('--set <kv>', 'Custom field', collect, [])
-    .action((opts) => {
-      const { db, config } = getCtx()
+    .action(async (opts) => {
+      const { db, config } = await getCtx()
       const cid = makeId('co')
       const n = now()
       const websites: string[] = []
       for (const w of opts.website) {
         const norm = normalizeWebsite(w)
-        checkDupeWebsite(db, norm)
+        await checkDupeWebsite(db, norm)
         websites.push(norm)
       }
       const phones: string[] = []
       for (const p of opts.phone) {
         try {
           const norm = normalizePhone(p, config.phone.default_country)
-          checkDupePhone(db, norm, 'companies')
+          await checkDupePhone(db, norm, 'companies')
           phones.push(norm)
         } catch (e: any) { die(`Error: invalid phone — ${e.message}`) }
       }
       const custom = parseKV(opts.set)
-      db.run('INSERT INTO companies (id,name,websites,phones,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?)',
-        [cid, opts.name, JSON.stringify(websites), JSON.stringify(phones), JSON.stringify(opts.tag), JSON.stringify(custom), n, n])
-      const row = db.query('SELECT * FROM companies WHERE id = ?').get(cid)
-      upsertSearchIndex(db, 'company', cid, buildCompanySearch(row))
+      await db.insert(schema.companies).values({
+        id: cid, name: opts.name, websites: JSON.stringify(websites), phones: JSON.stringify(phones),
+        tags: JSON.stringify(opts.tag), custom_fields: JSON.stringify(custom), created_at: n, updated_at: n
+      })
+      const results = await db.select().from(schema.companies).where(eq(schema.companies.id, cid))
+      const row = results[0]
+      await upsertSearchIndex(db, 'company', cid, buildCompanySearch(row))
       console.log(cid)
     })
 
@@ -47,20 +52,20 @@ export function registerCompanyCommands(program: Command) {
     .option('--sort <field>')
     .option('--limit <n>')
     .option('--filter <expr>')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let rows = (db.query('SELECT * FROM companies').all() as any[]).map(c => companyToRow(c, config))
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let rows = (await db.select().from(schema.companies)).map(c => companyToRow(c, config))
       if (opts.tag) rows = rows.filter(c => c.tags.includes(opts.tag))
       if (opts.sort) rows.sort((a, b) => String(a[opts.sort] ?? '').localeCompare(String(b[opts.sort] ?? '')))
       if (opts.limit) rows = rows.slice(0, Number(opts.limit))
       console.log(formatOutput(rows, fmt, config))
     })
 
-  cmd.command('show').argument('<ref>').action((ref) => {
-    const { db, config, fmt } = getCtx()
-    const co = resolveCompany(db, ref, config)
+  cmd.command('show').argument('<ref>').action(async (ref) => {
+    const { db, config, fmt } = await getCtx()
+    const co = await resolveCompany(db, ref, config)
     if (!co) die(`Error: company not found: ${ref}`)
-    showEntity(companyDetail(db, co, config), fmt)
+    showEntity(await companyDetail(db, co, config), fmt)
   })
 
   cmd.command('edit').argument('<ref>')
@@ -73,9 +78,9 @@ export function registerCompanyCommands(program: Command) {
     .option('--rm-tag <t>', '', collect, [])
     .option('--set <kv>', '', collect, [])
     .option('--unset <key>', '', collect, [])
-    .action((ref, opts) => {
-      const { db, config } = getCtx()
-      const co = resolveCompany(db, ref, config)
+    .action(async (ref, opts) => {
+      const { db, config } = await getCtx()
+      const co = await resolveCompany(db, ref, config)
       if (!co) die(`Error: company not found: ${ref}`)
       let websites: string[] = safeJSON(co.websites)
       let phones: string[] = safeJSON(co.phones)
@@ -86,14 +91,14 @@ export function registerCompanyCommands(program: Command) {
       for (const w of opts.addWebsite) {
         const norm = normalizeWebsite(w)
         if (websites.includes(norm)) die(`Error: duplicate website "${w}" — already on this company`)
-        checkDupeWebsite(db, norm, co.id)
+        await checkDupeWebsite(db, norm, co.id)
         websites.push(norm)
       }
       for (const w of opts.rmWebsite) { const norm = normalizeWebsite(w); websites = websites.filter(v => v !== norm) }
       for (const p of opts.addPhone) {
         const norm = normalizePhone(p, config.phone.default_country)
         if (phones.includes(norm)) die(`Error: duplicate phone "${p}" — already on this company`)
-        checkDupePhone(db, norm, 'companies', co.id)
+        await checkDupePhone(db, norm, 'companies', co.id)
         phones.push(norm)
       }
       for (const p of opts.rmPhone) {
@@ -105,58 +110,64 @@ export function registerCompanyCommands(program: Command) {
       const kvs = parseKV(opts.set)
       for (const [k, v] of Object.entries(kvs)) custom[k] = v
       for (const k of opts.unset) delete custom[k]
-      db.run('UPDATE companies SET name=?,websites=?,phones=?,tags=?,custom_fields=?,updated_at=? WHERE id=?',
-        [name, JSON.stringify(websites), JSON.stringify(phones), JSON.stringify(tags), JSON.stringify(custom), now(), co.id])
-      const row = db.query('SELECT * FROM companies WHERE id = ?').get(co.id)
-      upsertSearchIndex(db, 'company', co.id, buildCompanySearch(row))
+      await db.update(schema.companies).set({
+        name, websites: JSON.stringify(websites), phones: JSON.stringify(phones),
+        tags: JSON.stringify(tags), custom_fields: JSON.stringify(custom), updated_at: now()
+      }).where(eq(schema.companies.id, co.id))
+      const results = await db.select().from(schema.companies).where(eq(schema.companies.id, co.id))
+      const row = results[0]
+      await upsertSearchIndex(db, 'company', co.id, buildCompanySearch(row))
     })
 
-  cmd.command('rm').argument('<ref>').option('--force').action((ref) => {
-    const { db, config } = getCtx()
-    const co = resolveCompany(db, ref, config)
+  cmd.command('rm').argument('<ref>').option('--force').action(async (ref) => {
+    const { db, config } = await getCtx()
+    const co = await resolveCompany(db, ref, config)
     if (!co) die(`Error: company not found: ${ref}`)
     if (!runHook(config, 'pre-company-rm', { id: co.id, name: co.name }))
       die('Error: pre-company-rm hook rejected deletion')
     // Unlink from contacts
-    const contacts = db.query('SELECT * FROM contacts').all() as any[]
-    for (const ct of contacts) {
+    const allContacts = await db.select().from(schema.contacts)
+    for (const ct of allContacts) {
       const companies: string[] = safeJSON(ct.companies)
       if (companies.includes(co.name))
-        db.run('UPDATE contacts SET companies=? WHERE id=?', [JSON.stringify(companies.filter(n => n !== co.name)), ct.id])
+        await db.update(schema.contacts).set({ companies: JSON.stringify(companies.filter(n => n !== co.name)) }).where(eq(schema.contacts.id, ct.id))
     }
     // Set deals company to null
-    db.run('UPDATE deals SET company=NULL WHERE company=?', [co.id])
-    db.run('DELETE FROM companies WHERE id=?', [co.id])
-    removeSearchIndex(db, co.id)
+    await db.update(schema.deals).set({ company: null }).where(eq(schema.deals.company, co.id))
+    await db.delete(schema.companies).where(eq(schema.companies.id, co.id))
+    await removeSearchIndex(db, co.id)
     runHook(config, 'post-company-rm', { id: co.id, name: co.name })
   })
 
-  cmd.command('merge').argument('<id1>').argument('<id2>').option('--keep-first').action((id1, id2) => {
-    const { db, config } = getCtx()
-    const c1 = resolveCompany(db, id1, config), c2 = resolveCompany(db, id2, config)
+  cmd.command('merge').argument('<id1>').argument('<id2>').option('--keep-first').action(async (id1, id2) => {
+    const { db, config } = await getCtx()
+    const c1 = await resolveCompany(db, id1, config), c2 = await resolveCompany(db, id2, config)
     if (!c1 || !c2) die('Error: one or both companies not found')
     const mergedWebsites = [...new Set([...safeJSON(c1.websites), ...safeJSON(c2.websites)])]
     const mergedPhones = [...new Set([...safeJSON(c1.phones), ...safeJSON(c2.phones)])]
     const mergedTags = [...new Set([...safeJSON(c1.tags), ...safeJSON(c2.tags)])]
     const mergedCustom = { ...safeJSON(c2.custom_fields), ...safeJSON(c1.custom_fields) }
-    db.run('UPDATE companies SET websites=?,phones=?,tags=?,custom_fields=?,updated_at=? WHERE id=?',
-      [JSON.stringify(mergedWebsites), JSON.stringify(mergedPhones), JSON.stringify(mergedTags), JSON.stringify(mergedCustom), now(), c1.id])
+    await db.update(schema.companies).set({
+      websites: JSON.stringify(mergedWebsites), phones: JSON.stringify(mergedPhones),
+      tags: JSON.stringify(mergedTags), custom_fields: JSON.stringify(mergedCustom), updated_at: now()
+    }).where(eq(schema.companies.id, c1.id))
     // Relink contacts
-    const contacts = db.query('SELECT * FROM contacts').all() as any[]
-    for (const ct of contacts) {
+    const allContacts = await db.select().from(schema.contacts)
+    for (const ct of allContacts) {
       const companies: string[] = safeJSON(ct.companies)
       if (companies.includes(c2.name)) {
         const updated = [...new Set(companies.map(n => n === c2.name ? c1.name : n))]
-        db.run('UPDATE contacts SET companies=? WHERE id=?', [JSON.stringify(updated), ct.id])
+        await db.update(schema.contacts).set({ companies: JSON.stringify(updated) }).where(eq(schema.contacts.id, ct.id))
       }
     }
     // Relink deals
-    db.run('UPDATE deals SET company=? WHERE company=?', [c1.id, c2.id])
+    await db.update(schema.deals).set({ company: c1.id }).where(eq(schema.deals.company, c2.id))
     // Transfer activities
-    db.run('UPDATE activities SET company=? WHERE company=?', [c1.id, c2.id])
-    db.run('DELETE FROM companies WHERE id=?', [c2.id])
-    removeSearchIndex(db, c2.id)
-    const row = db.query('SELECT * FROM companies WHERE id = ?').get(c1.id)
-    upsertSearchIndex(db, 'company', c1.id, buildCompanySearch(row))
+    await db.update(schema.activities).set({ company: c1.id }).where(eq(schema.activities.company, c2.id))
+    await db.delete(schema.companies).where(eq(schema.companies.id, c2.id))
+    await removeSearchIndex(db, c2.id)
+    const results = await db.select().from(schema.companies).where(eq(schema.companies.id, c1.id))
+    const row = results[0]
+    await upsertSearchIndex(db, 'company', c1.id, buildCompanySearch(row))
   })
 }

--- a/src/commands/contact.ts
+++ b/src/commands/contact.ts
@@ -1,3 +1,4 @@
+import { eq, sql } from 'drizzle-orm'
 import type { Command } from 'commander'
 import { getCtx, makeId, now, die, collect, parseKV, checkDupeEmail, checkDupePhone, checkDupeSocial,
   getOrCreateCompany, buildContactSearch, contactDetail, showEntity } from '../lib/helpers'
@@ -7,6 +8,7 @@ import { resolveContact } from '../resolve'
 import { upsertSearchIndex, removeSearchIndex } from '../db'
 import { parseFilter, applyFilter } from '../filter'
 import { runHook } from '../hooks'
+import * as schema from '../drizzle-schema'
 
 export function registerContactCommands(program: Command) {
   const cmd = program.command('contact').description('Manage contacts')
@@ -22,16 +24,16 @@ export function registerContactCommands(program: Command) {
     .option('--bluesky <h>', 'Bluesky')
     .option('--telegram <h>', 'Telegram')
     .option('--set <kv>', 'Custom field', collect, [])
-    .action((opts) => {
-      const { db, config } = getCtx()
+    .action(async (opts) => {
+      const { db, config } = await getCtx()
       const cid = makeId('ct')
       const n = now()
-      for (const e of opts.email) checkDupeEmail(db, e)
+      for (const e of opts.email) await checkDupeEmail(db, e)
       const phones: string[] = []
       for (const p of opts.phone) {
         try {
           const norm = normalizePhone(p, config.phone.default_country)
-          checkDupePhone(db, norm, 'contacts')
+          await checkDupePhone(db, norm, 'contacts')
           phones.push(norm)
         } catch (e: any) { die(`Error: invalid phone — ${e.message}`) }
       }
@@ -39,18 +41,21 @@ export function registerContactCommands(program: Command) {
       const x = opts.x ? normalizeSocialHandle('x', opts.x) : null
       const bluesky = opts.bluesky ? normalizeSocialHandle('bluesky', opts.bluesky) : null
       const telegram = opts.telegram ? normalizeSocialHandle('telegram', opts.telegram) : null
-      if (linkedin) checkDupeSocial(db, 'linkedin', linkedin)
-      if (x) checkDupeSocial(db, 'x', x)
-      if (bluesky) checkDupeSocial(db, 'bluesky', bluesky)
-      if (telegram) checkDupeSocial(db, 'telegram', telegram)
+      if (linkedin) await checkDupeSocial(db, 'linkedin', linkedin)
+      if (x) await checkDupeSocial(db, 'x', x)
+      if (bluesky) await checkDupeSocial(db, 'bluesky', bluesky)
+      if (telegram) await checkDupeSocial(db, 'telegram', telegram)
       const companies: string[] = []
-      for (const c of opts.company) companies.push(getOrCreateCompany(db, c, config))
+      for (const c of opts.company) companies.push(await getOrCreateCompany(db, c, config))
       const custom = parseKV(opts.set)
-      db.run('INSERT INTO contacts (id,name,emails,phones,companies,linkedin,x,bluesky,telegram,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
-        [cid, opts.name, JSON.stringify(opts.email), JSON.stringify(phones), JSON.stringify(companies),
-         linkedin, x, bluesky, telegram, JSON.stringify(opts.tag), JSON.stringify(custom), n, n])
-      const row = db.query('SELECT * FROM contacts WHERE id = ?').get(cid)
-      upsertSearchIndex(db, 'contact', cid, buildContactSearch(row))
+      await db.insert(schema.contacts).values({
+        id: cid, name: opts.name, emails: JSON.stringify(opts.email), phones: JSON.stringify(phones),
+        companies: JSON.stringify(companies), linkedin, x, bluesky, telegram,
+        tags: JSON.stringify(opts.tag), custom_fields: JSON.stringify(custom), created_at: n, updated_at: n
+      })
+      const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, cid))
+      const row = results[0]
+      await upsertSearchIndex(db, 'contact', cid, buildContactSearch(row))
       runHook(config, 'post-contact-add', { id: cid, name: opts.name, emails: opts.email, phones, companies, linkedin, x, bluesky, telegram, tags: opts.tag, custom_fields: custom })
       console.log(cid)
     })
@@ -62,9 +67,9 @@ export function registerContactCommands(program: Command) {
     .option('--limit <n>')
     .option('--offset <n>')
     .option('--filter <expr>')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let rows = (db.query('SELECT * FROM contacts').all() as any[]).map(c => contactToRow(c, config))
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let rows = (await db.select().from(schema.contacts)).map(c => contactToRow(c, config))
       if (opts.tag) rows = rows.filter(c => c.tags.includes(opts.tag))
       if (opts.company) rows = rows.filter(c => c.companies.includes(opts.company))
       if (opts.filter) { const f = parseFilter(opts.filter); rows = rows.filter(c => applyFilter(c, f)) }
@@ -74,11 +79,11 @@ export function registerContactCommands(program: Command) {
       console.log(formatOutput(rows, fmt, config))
     })
 
-  cmd.command('show').argument('<ref>').action((ref) => {
-    const { db, config, fmt } = getCtx()
-    const c = resolveContact(db, ref, config)
+  cmd.command('show').argument('<ref>').action(async (ref) => {
+    const { db, config, fmt } = await getCtx()
+    const c = await resolveContact(db, ref, config)
     if (!c) die(`Error: contact not found: ${ref}`)
-    showEntity(contactDetail(db, c, config), fmt)
+    showEntity(await contactDetail(db, c, config), fmt)
   })
 
   cmd.command('edit').argument('<ref>')
@@ -97,9 +102,9 @@ export function registerContactCommands(program: Command) {
     .option('--telegram <h>')
     .option('--set <kv>', '', collect, [])
     .option('--unset <key>', '', collect, [])
-    .action((ref, opts) => {
-      const { db, config } = getCtx()
-      const c = resolveContact(db, ref, config)
+    .action(async (ref, opts) => {
+      const { db, config } = await getCtx()
+      const c = await resolveContact(db, ref, config)
       if (!c) die(`Error: contact not found: ${ref}`)
       let emails: string[] = safeJSON(c.emails)
       let phones: string[] = safeJSON(c.phones)
@@ -108,19 +113,19 @@ export function registerContactCommands(program: Command) {
       let custom: Record<string, any> = safeJSON(c.custom_fields)
       let name = c.name, linkedin = c.linkedin, x = c.x, bluesky = c.bluesky, telegram = c.telegram
       if (opts.name) name = opts.name
-      for (const e of opts.addEmail) { checkDupeEmail(db, e, c.id); if (!emails.includes(e)) emails.push(e) }
+      for (const e of opts.addEmail) { await checkDupeEmail(db, e, c.id); if (!emails.includes(e)) emails.push(e) }
       for (const e of opts.rmEmail) emails = emails.filter(v => v !== e)
       for (const p of opts.addPhone) {
         const norm = normalizePhone(p, config.phone.default_country)
         if (phones.includes(norm)) die(`Error: duplicate phone "${p}" — already on this contact`)
-        checkDupePhone(db, norm, 'contacts', c.id)
+        await checkDupePhone(db, norm, 'contacts', c.id)
         phones.push(norm)
       }
       for (const p of opts.rmPhone) {
         const norm = tryNormalizePhone(p, config.phone.default_country)
         phones = norm ? phones.filter(v => v !== norm) : phones.filter(v => v !== p)
       }
-      for (const co of opts.addCompany) { const n = getOrCreateCompany(db, co, config); if (!companies.includes(n)) companies.push(n) }
+      for (const co of opts.addCompany) { const n = await getOrCreateCompany(db, co, config); if (!companies.includes(n)) companies.push(n) }
       for (const co of opts.rmCompany) companies = companies.filter(v => v !== co)
       for (const t of opts.addTag) { if (!tags.includes(t)) tags.push(t) }
       for (const t of opts.rmTag) tags = tags.filter(v => v !== t)
@@ -137,32 +142,36 @@ export function registerContactCommands(program: Command) {
         if (k === 'bluesky') bluesky = null
         if (k === 'telegram') telegram = null
       }
-      db.run('UPDATE contacts SET name=?,emails=?,phones=?,companies=?,linkedin=?,x=?,bluesky=?,telegram=?,tags=?,custom_fields=?,updated_at=? WHERE id=?',
-        [name, JSON.stringify(emails), JSON.stringify(phones), JSON.stringify(companies), linkedin, x, bluesky, telegram, JSON.stringify(tags), JSON.stringify(custom), now(), c.id])
-      const row = db.query('SELECT * FROM contacts WHERE id = ?').get(c.id)
-      upsertSearchIndex(db, 'contact', c.id, buildContactSearch(row))
+      await db.update(schema.contacts).set({
+        name, emails: JSON.stringify(emails), phones: JSON.stringify(phones),
+        companies: JSON.stringify(companies), linkedin, x, bluesky, telegram,
+        tags: JSON.stringify(tags), custom_fields: JSON.stringify(custom), updated_at: now()
+      }).where(eq(schema.contacts.id, c.id))
+      const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, c.id))
+      const row = results[0]
+      await upsertSearchIndex(db, 'contact', c.id, buildContactSearch(row))
     })
 
-  cmd.command('rm').argument('<ref>').option('--force').action((ref) => {
-    const { db, config } = getCtx()
-    const c = resolveContact(db, ref, config)
+  cmd.command('rm').argument('<ref>').option('--force').action(async (ref) => {
+    const { db, config } = await getCtx()
+    const c = await resolveContact(db, ref, config)
     if (!c) die(`Error: contact not found: ${ref}`)
     if (!runHook(config, 'pre-contact-rm', { id: c.id, name: c.name }))
       die('Error: pre-contact-rm hook rejected deletion')
-    const deals = db.query('SELECT * FROM deals').all() as any[]
-    for (const d of deals) {
+    const allDeals = await db.select().from(schema.deals)
+    for (const d of allDeals) {
       const contacts: string[] = safeJSON(d.contacts)
       if (contacts.includes(c.id))
-        db.run('UPDATE deals SET contacts=? WHERE id=?', [JSON.stringify(contacts.filter(id => id !== c.id)), d.id])
+        await db.update(schema.deals).set({ contacts: JSON.stringify(contacts.filter(id => id !== c.id)) }).where(eq(schema.deals.id, d.id))
     }
-    db.run('DELETE FROM contacts WHERE id=?', [c.id])
-    removeSearchIndex(db, c.id)
+    await db.delete(schema.contacts).where(eq(schema.contacts.id, c.id))
+    await removeSearchIndex(db, c.id)
     runHook(config, 'post-contact-rm', { id: c.id, name: c.name })
   })
 
-  cmd.command('merge').argument('<id1>').argument('<id2>').option('--keep-first').action((id1, id2) => {
-    const { db, config } = getCtx()
-    const c1 = resolveContact(db, id1, config), c2 = resolveContact(db, id2, config)
+  cmd.command('merge').argument('<id1>').argument('<id2>').option('--keep-first').action(async (id1, id2) => {
+    const { db, config } = await getCtx()
+    const c1 = await resolveContact(db, id1, config), c2 = await resolveContact(db, id2, config)
     if (!c1 || !c2) die('Error: one or both contacts not found')
     const mergedEmails = [...new Set([...safeJSON(c1.emails), ...safeJSON(c2.emails)])]
     const mergedPhones = [...new Set([...safeJSON(c1.phones), ...safeJSON(c2.phones)])]
@@ -174,22 +183,25 @@ export function registerContactCommands(program: Command) {
     const bluesky = c1.bluesky || c2.bluesky
     const telegram = c1.telegram || c2.telegram
     // Clear loser's social handles to avoid UNIQUE constraint conflicts, then delete loser first
-    db.run('UPDATE contacts SET linkedin=NULL,x=NULL,bluesky=NULL,telegram=NULL WHERE id=?', [c2.id])
-    db.run('UPDATE contacts SET emails=?,phones=?,companies=?,tags=?,custom_fields=?,linkedin=?,x=?,bluesky=?,telegram=?,updated_at=? WHERE id=?',
-      [JSON.stringify(mergedEmails), JSON.stringify(mergedPhones), JSON.stringify(mergedCompanies),
-       JSON.stringify(mergedTags), JSON.stringify(mergedCustom), linkedin, x, bluesky, telegram, now(), c1.id])
-    const deals = db.query('SELECT * FROM deals').all() as any[]
-    for (const d of deals) {
+    await db.update(schema.contacts).set({ linkedin: null, x: null, bluesky: null, telegram: null }).where(eq(schema.contacts.id, c2.id))
+    await db.update(schema.contacts).set({
+      emails: JSON.stringify(mergedEmails), phones: JSON.stringify(mergedPhones),
+      companies: JSON.stringify(mergedCompanies), tags: JSON.stringify(mergedTags),
+      custom_fields: JSON.stringify(mergedCustom), linkedin, x, bluesky, telegram, updated_at: now()
+    }).where(eq(schema.contacts.id, c1.id))
+    const allDeals = await db.select().from(schema.deals)
+    for (const d of allDeals) {
       const contacts: string[] = safeJSON(d.contacts)
       if (contacts.includes(c2.id)) {
         const updated = [...new Set(contacts.map(id => id === c2.id ? c1.id : id))]
-        db.run('UPDATE deals SET contacts=? WHERE id=?', [JSON.stringify(updated), d.id])
+        await db.update(schema.deals).set({ contacts: JSON.stringify(updated) }).where(eq(schema.deals.id, d.id))
       }
     }
-    db.run('UPDATE activities SET contact=? WHERE contact=?', [c1.id, c2.id])
-    db.run('DELETE FROM contacts WHERE id=?', [c2.id])
-    removeSearchIndex(db, c2.id)
-    const row = db.query('SELECT * FROM contacts WHERE id = ?').get(c1.id)
-    upsertSearchIndex(db, 'contact', c1.id, buildContactSearch(row))
+    await db.update(schema.activities).set({ contact: c1.id }).where(eq(schema.activities.contact, c2.id))
+    await db.delete(schema.contacts).where(eq(schema.contacts.id, c2.id))
+    await removeSearchIndex(db, c2.id)
+    const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, c1.id))
+    const row = results[0]
+    await upsertSearchIndex(db, 'contact', c1.id, buildContactSearch(row))
   })
 }

--- a/src/commands/deal.ts
+++ b/src/commands/deal.ts
@@ -1,9 +1,11 @@
+import { eq, sql } from 'drizzle-orm'
 import type { Command } from 'commander'
 import { getCtx, makeId, now, die, collect, parseKV, buildDealSearch, dealDetail, showEntity, getOrCreateCompanyId } from '../lib/helpers'
 import { resolveContact, resolveCompanyForLink, resolveDeal } from '../resolve'
 import { formatOutput, dealToRow, safeJSON } from '../format'
 import { upsertSearchIndex, removeSearchIndex } from '../db'
 import { runHook } from '../hooks'
+import * as schema from '../drizzle-schema'
 
 export function registerDealCommands(program: Command) {
   const cmd = program.command('deal').description('Manage deals')
@@ -18,8 +20,8 @@ export function registerDealCommands(program: Command) {
     .option('--probability <n>', 'Win probability 0-100')
     .option('--tag <tag>', 'Tag', collect, [])
     .option('--set <kv>', 'Custom field', collect, [])
-    .action((opts) => {
-      const { db, config } = getCtx()
+    .action(async (opts) => {
+      const { db, config } = await getCtx()
       const id = makeId('dl')
       const n = now()
       if (opts.value !== undefined && Number(opts.value) < 0) die('Error: value must be non-negative')
@@ -35,28 +37,32 @@ export function registerDealCommands(program: Command) {
       if (!config.pipeline.stages.includes(stage)) die(`Error: invalid stage "${stage}"`)
       const contactIds: string[] = []
       for (const ref of opts.contact) {
-        const ct = resolveContact(db, ref, config)
+        const ct = await resolveContact(db, ref, config)
         if (!ct) die(`Error: contact not found: ${ref}`)
         contactIds.push(ct.id)
       }
       let companyId: string | null = null
       if (opts.company) {
-        const co = resolveCompanyForLink(db, opts.company, config)
+        const co = await resolveCompanyForLink(db, opts.company, config)
         if (co) {
           companyId = co.id
         } else {
           // Auto-create only for plain names (no dots suggesting domain)
           if (opts.company.includes('.')) die(`Error: company not found: ${opts.company}`)
-          companyId = getOrCreateCompanyId(db, opts.company, config)
+          companyId = await getOrCreateCompanyId(db, opts.company, config)
         }
       }
       const custom = parseKV(opts.set)
       const value = opts.value !== undefined ? Number(opts.value) : null
       const probability = opts.probability !== undefined ? Number(opts.probability) : null
-      db.run('INSERT INTO deals (id,title,value,stage,contacts,company,expected_close,probability,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
-        [id, opts.title, value, stage, JSON.stringify(contactIds), companyId, opts.expectedClose || null, probability, JSON.stringify(opts.tag), JSON.stringify(custom), n, n])
-      const row = db.query('SELECT * FROM deals WHERE id = ?').get(id)
-      upsertSearchIndex(db, 'deal', id, buildDealSearch(row))
+      await db.insert(schema.deals).values({
+        id, title: opts.title, value, stage, contacts: JSON.stringify(contactIds),
+        company: companyId, expected_close: opts.expectedClose || null, probability,
+        tags: JSON.stringify(opts.tag), custom_fields: JSON.stringify(custom), created_at: n, updated_at: n
+      })
+      const results = await db.select().from(schema.deals).where(eq(schema.deals.id, id))
+      const row = results[0]
+      await upsertSearchIndex(db, 'deal', id, buildDealSearch(row))
       console.log(id)
     })
 
@@ -67,14 +73,14 @@ export function registerDealCommands(program: Command) {
     .option('--contact <ref>')
     .option('--sort <field>')
     .option('--limit <n>')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let rows = (db.query('SELECT * FROM deals').all() as any[]).map(d => dealToRow(d, config))
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let rows = (await db.select().from(schema.deals)).map(d => dealToRow(d, config))
       if (opts.stage) rows = rows.filter(d => d.stage === opts.stage)
       if (opts.minValue) rows = rows.filter(d => (d.value ?? 0) >= Number(opts.minValue))
       if (opts.maxValue) rows = rows.filter(d => (d.value ?? 0) <= Number(opts.maxValue))
       if (opts.contact) {
-        const ct = resolveContact(db, opts.contact, config)
+        const ct = await resolveContact(db, opts.contact, config)
         if (ct) rows = rows.filter(d => d.contacts.includes(ct.id))
         else rows = []
       }
@@ -89,11 +95,11 @@ export function registerDealCommands(program: Command) {
       console.log(formatOutput(rows, fmt, config))
     })
 
-  cmd.command('show').argument('<ref>').action((ref) => {
-    const { db, config, fmt } = getCtx()
-    const d = resolveDeal(db, ref)
+  cmd.command('show').argument('<ref>').action(async (ref) => {
+    const { db, config, fmt } = await getCtx()
+    const d = await resolveDeal(db, ref)
     if (!d) die(`Error: deal not found: ${ref}`)
-    showEntity(dealDetail(db, d, config), fmt)
+    showEntity(await dealDetail(db, d, config), fmt)
   })
 
   cmd.command('edit').argument('<ref>')
@@ -105,9 +111,9 @@ export function registerDealCommands(program: Command) {
     .option('--rm-tag <t>', '', collect, [])
     .option('--set <kv>', '', collect, [])
     .option('--unset <key>', '', collect, [])
-    .action((ref, opts) => {
-      const { db, config } = getCtx()
-      const d = resolveDeal(db, ref)
+    .action(async (ref, opts) => {
+      const { db, config } = await getCtx()
+      const d = await resolveDeal(db, ref)
       if (!d) die(`Error: deal not found: ${ref}`)
       const title = opts.title ?? d.title
       const value = opts.value !== undefined ? Number(opts.value) : d.value
@@ -115,12 +121,12 @@ export function registerDealCommands(program: Command) {
       let tags: string[] = safeJSON(d.tags)
       let custom: Record<string, any> = safeJSON(d.custom_fields)
       for (const r of opts.addContact) {
-        const ct = resolveContact(db, r, config)
+        const ct = await resolveContact(db, r, config)
         if (!ct) die(`Error: contact not found: ${r}`)
         if (!contacts.includes(ct.id)) contacts.push(ct.id)
       }
       for (const r of opts.rmContact) {
-        const ct = resolveContact(db, r, config)
+        const ct = await resolveContact(db, r, config)
         if (ct) contacts = contacts.filter(id => id !== ct.id)
       }
       for (const t of opts.addTag) { if (!tags.includes(t)) tags.push(t) }
@@ -128,49 +134,53 @@ export function registerDealCommands(program: Command) {
       const kvs = parseKV(opts.set)
       for (const [k, v] of Object.entries(kvs)) custom[k] = v
       for (const k of opts.unset) delete custom[k]
-      db.run('UPDATE deals SET title=?,value=?,contacts=?,tags=?,custom_fields=?,updated_at=? WHERE id=?',
-        [title, value, JSON.stringify(contacts), JSON.stringify(tags), JSON.stringify(custom), now(), d.id])
-      const row = db.query('SELECT * FROM deals WHERE id = ?').get(d.id)
-      upsertSearchIndex(db, 'deal', d.id, buildDealSearch(row))
+      await db.update(schema.deals).set({
+        title, value, contacts: JSON.stringify(contacts),
+        tags: JSON.stringify(tags), custom_fields: JSON.stringify(custom), updated_at: now()
+      }).where(eq(schema.deals.id, d.id))
+      const results = await db.select().from(schema.deals).where(eq(schema.deals.id, d.id))
+      const row = results[0]
+      await upsertSearchIndex(db, 'deal', d.id, buildDealSearch(row))
     })
 
   cmd.command('move').argument('<ref>')
     .requiredOption('--stage <stage>', 'Target stage')
     .option('--note <text>', 'Note')
     .option('--reason <text>', 'Reason')
-    .action((ref, opts) => {
-      const { db, config } = getCtx()
-      const d = resolveDeal(db, ref)
+    .action(async (ref, opts) => {
+      const { db, config } = await getCtx()
+      const d = await resolveDeal(db, ref)
       if (!d) die(`Error: deal not found: ${ref}`)
       if (!config.pipeline.stages.includes(opts.stage)) die(`Error: invalid stage "${opts.stage}"`)
       if (d.stage === opts.stage) die(`Error: deal is already in stage "${opts.stage}"`)
       const oldStage = d.stage
       const n = now()
-      db.run('UPDATE deals SET stage=?,updated_at=? WHERE id=?', [opts.stage, n, d.id])
+      await db.update(schema.deals).set({ stage: opts.stage, updated_at: n }).where(eq(schema.deals.id, d.id))
       let body = `from ${oldStage} to ${opts.stage}`
       if (opts.note) body += ` | ${opts.note}`
       if (opts.reason) body += ` | ${opts.reason}`
       const aid = makeId('ac')
-      db.run('INSERT INTO activities (id,type,body,deal,created_at) VALUES (?,?,?,?,?)',
-        [aid, 'stage-change', body, d.id, n])
-      upsertSearchIndex(db, 'activity', aid, `stage-change ${body}`)
+      await db.insert(schema.activities).values({
+        id: aid, type: 'stage-change', body, deal: d.id, created_at: n
+      })
+      await upsertSearchIndex(db, 'activity', aid, `stage-change ${body}`)
       runHook(config, 'post-deal-stage-change', { deal: d.id, from: oldStage, to: opts.stage, note: opts.note, reason: opts.reason })
     })
 
-  cmd.command('rm').argument('<ref>').option('--force').action((ref) => {
-    const { db } = getCtx()
-    const d = resolveDeal(db, ref)
+  cmd.command('rm').argument('<ref>').option('--force').action(async (ref) => {
+    const { db } = await getCtx()
+    const d = await resolveDeal(db, ref)
     if (!d) die(`Error: deal not found: ${ref}`)
-    db.run('DELETE FROM activities WHERE deal = ?', [d.id])
-    db.run('DELETE FROM deals WHERE id = ?', [d.id])
-    removeSearchIndex(db, d.id)
+    await db.delete(schema.activities).where(eq(schema.activities.deal, d.id))
+    await db.delete(schema.deals).where(eq(schema.deals.id, d.id))
+    await removeSearchIndex(db, d.id)
   })
 }
 
 export function registerPipelineCommand(program: Command) {
-  program.command('pipeline').description('Pipeline summary').action(() => {
-    const { db, config, fmt } = getCtx()
-    const deals = db.query('SELECT * FROM deals').all() as any[]
+  program.command('pipeline').description('Pipeline summary').action(async () => {
+    const { db, config, fmt } = await getCtx()
+    const deals = await db.select().from(schema.deals)
     const summary = config.pipeline.stages.map(stage => ({
       stage,
       count: deals.filter(d => d.stage === stage).length,

--- a/src/commands/dupes.ts
+++ b/src/commands/dupes.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander'
 import { getCtx, levenshtein } from '../lib/helpers'
 import { formatOutput, contactToRow, companyToRow, safeJSON } from '../format'
+import * as schema from '../drizzle-schema'
 
 export function registerDupesCommand(program: Command) {
   program.command('dupes')
@@ -8,13 +9,13 @@ export function registerDupesCommand(program: Command) {
     .option('--type <type>', 'Entity type (contact or company)')
     .option('--threshold <n>', 'Similarity threshold 0-1', '0.3')
     .option('--limit <n>', 'Max results')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
       const threshold = Number(opts.threshold)
       let results: any[] = []
 
       if (!opts.type || opts.type === 'contact') {
-        const contacts = db.query('SELECT * FROM contacts').all() as any[]
+        const contacts = await db.select().from(schema.contacts)
         for (let i = 0; i < contacts.length; i++) {
           for (let j = i + 1; j < contacts.length; j++) {
             const reasons = contactDupeReasons(contacts[i], contacts[j])
@@ -32,7 +33,7 @@ export function registerDupesCommand(program: Command) {
       }
 
       if (!opts.type || opts.type === 'company') {
-        const companies = db.query('SELECT * FROM companies').all() as any[]
+        const companies = await db.select().from(schema.companies)
         for (let i = 0; i < companies.length; i++) {
           for (let j = i + 1; j < companies.length; j++) {
             const reasons = companyDupeReasons(companies[i], companies[j])

--- a/src/commands/importexport.ts
+++ b/src/commands/importexport.ts
@@ -1,10 +1,13 @@
+import { eq, sql } from 'drizzle-orm'
 import { readFileSync } from 'node:fs'
 import type { Command } from 'commander'
 import { getCtx, makeId, now, die, collect, parseCSV, buildContactSearch, buildCompanySearch, buildDealSearch } from '../lib/helpers'
 import { resolveContact, resolveCompany } from '../resolve'
 import { formatOutput, contactToRow, companyToRow, dealToRow, activityToRow, safeJSON } from '../format'
 import { upsertSearchIndex } from '../db'
+import type { DB } from '../db'
 import { tryNormalizePhone, normalizeWebsite } from '../normalize'
+import * as schema from '../drizzle-schema'
 
 const CONTACT_FIELDS = new Set(['name', 'email', 'emails', 'phone', 'phones', 'company', 'companies', 'tags', 'linkedin', 'x', 'bluesky', 'telegram'])
 const COMPANY_FIELDS = new Set(['name', 'website', 'websites', 'phone', 'phones', 'tags'])
@@ -14,8 +17,8 @@ export function registerImportExportCommands(program: Command) {
   const imp = program.command('import').description('Import data')
 
   imp.command('contacts').argument('<file>').option('--dry-run').option('--skip-errors').option('--update')
-    .action((file, opts) => {
-      const { db, config } = getCtx()
+    .action(async (file, opts) => {
+      const { db, config } = await getCtx()
       const records = readRecords(file)
       let imported = 0, skipped = 0, errors = 0
       for (const rec of records) {
@@ -32,7 +35,7 @@ export function registerImportExportCommands(program: Command) {
           // Check for existing by email
           let existing: any = null
           for (const e of emails) {
-            existing = findContactByEmail(db, e)
+            existing = await findContactByEmail(db, e)
             if (existing) break
           }
           if (existing && !opts.update) { skipped++; continue }
@@ -41,10 +44,12 @@ export function registerImportExportCommands(program: Command) {
             for (const [k, v] of Object.entries(rec)) {
               if (!CONTACT_FIELDS.has(k) && v) custom[k] = v
             }
-            db.run('UPDATE contacts SET name=?,custom_fields=?,updated_at=? WHERE id=?',
-              [name || existing.name, JSON.stringify(custom), now(), existing.id])
-            const row = db.query('SELECT * FROM contacts WHERE id = ?').get(existing.id)
-            upsertSearchIndex(db, 'contact', existing.id, buildContactSearch(row))
+            await db.update(schema.contacts).set({
+              name: name || existing.name, custom_fields: JSON.stringify(custom), updated_at: now()
+            }).where(eq(schema.contacts.id, existing.id))
+            const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, existing.id))
+            const row = results[0]
+            await upsertSearchIndex(db, 'contact', existing.id, buildContactSearch(row))
             imported++
             continue
           }
@@ -56,10 +61,15 @@ export function registerImportExportCommands(program: Command) {
             if (!CONTACT_FIELDS.has(k) && v) custom[k] = v
           }
           const social: Record<string, string | null> = { linkedin: rec.linkedin || null, x: rec.x || null, bluesky: rec.bluesky || null, telegram: rec.telegram || null }
-          db.run('INSERT INTO contacts (id,name,emails,phones,companies,linkedin,x,bluesky,telegram,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
-            [id, name, JSON.stringify(emails), JSON.stringify(phones), JSON.stringify(companies), social.linkedin, social.x, social.bluesky, social.telegram, JSON.stringify(tags), JSON.stringify(custom), n, n])
-          const row = db.query('SELECT * FROM contacts WHERE id = ?').get(id)
-          upsertSearchIndex(db, 'contact', id, buildContactSearch(row))
+          await db.insert(schema.contacts).values({
+            id, name, emails: JSON.stringify(emails), phones: JSON.stringify(phones),
+            companies: JSON.stringify(companies), linkedin: social.linkedin, x: social.x,
+            bluesky: social.bluesky, telegram: social.telegram,
+            tags: JSON.stringify(tags), custom_fields: JSON.stringify(custom), created_at: n, updated_at: n
+          })
+          const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, id))
+          const row = results[0]
+          await upsertSearchIndex(db, 'contact', id, buildContactSearch(row))
           imported++
         } catch (e: any) {
           if (opts.skipErrors) { errors++; continue }
@@ -70,8 +80,8 @@ export function registerImportExportCommands(program: Command) {
     })
 
   imp.command('companies').argument('<file>').option('--dry-run').option('--skip-errors')
-    .action((file, opts) => {
-      const { db, config } = getCtx()
+    .action(async (file, opts) => {
+      const { db, config } = await getCtx()
       const records = readRecords(file)
       let imported = 0
       for (const rec of records) {
@@ -92,10 +102,13 @@ export function registerImportExportCommands(program: Command) {
           if (opts.dryRun) { console.log(`[dry-run] ${rec.name}`); imported++; continue }
           const id = makeId('co')
           const n = now()
-          db.run('INSERT INTO companies (id,name,websites,phones,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?)',
-            [id, rec.name, JSON.stringify(websites), JSON.stringify(phones), JSON.stringify(tags), JSON.stringify(custom), n, n])
-          const row = db.query('SELECT * FROM companies WHERE id = ?').get(id)
-          upsertSearchIndex(db, 'company', id, buildCompanySearch(row))
+          await db.insert(schema.companies).values({
+            id, name: rec.name, websites: JSON.stringify(websites), phones: JSON.stringify(phones),
+            tags: JSON.stringify(tags), custom_fields: JSON.stringify(custom), created_at: n, updated_at: n
+          })
+          const results = await db.select().from(schema.companies).where(eq(schema.companies.id, id))
+          const row = results[0]
+          await upsertSearchIndex(db, 'company', id, buildCompanySearch(row))
           imported++
         } catch (e: any) {
           if (opts.skipErrors) continue
@@ -106,8 +119,8 @@ export function registerImportExportCommands(program: Command) {
     })
 
   imp.command('deals').argument('<file>').option('--dry-run').option('--skip-errors')
-    .action((file, opts) => {
-      const { db, config } = getCtx()
+    .action(async (file, opts) => {
+      const { db, config } = await getCtx()
       const records = readRecords(file)
       let imported = 0
       for (const rec of records) {
@@ -123,10 +136,15 @@ export function registerImportExportCommands(program: Command) {
           if (opts.dryRun) { console.log(`[dry-run] ${rec.title}`); imported++; continue }
           const id = makeId('dl')
           const n = now()
-          db.run('INSERT INTO deals (id,title,value,stage,contacts,company,expected_close,probability,tags,custom_fields,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
-            [id, rec.title, value, stage, '[]', null, rec.expected_close || null, rec.probability ? Number(rec.probability) : null, JSON.stringify(tags), JSON.stringify(custom), n, n])
-          const row = db.query('SELECT * FROM deals WHERE id = ?').get(id)
-          upsertSearchIndex(db, 'deal', id, buildDealSearch(row))
+          await db.insert(schema.deals).values({
+            id, title: rec.title, value, stage, contacts: '[]', company: null,
+            expected_close: rec.expected_close || null,
+            probability: rec.probability ? Number(rec.probability) : null,
+            tags: JSON.stringify(tags), custom_fields: JSON.stringify(custom), created_at: n, updated_at: n
+          })
+          const results = await db.select().from(schema.deals).where(eq(schema.deals.id, id))
+          const row = results[0]
+          await upsertSearchIndex(db, 'deal', id, buildDealSearch(row))
           imported++
         } catch (e: any) {
           if (opts.skipErrors) continue
@@ -137,28 +155,28 @@ export function registerImportExportCommands(program: Command) {
     })
 
   const exp = program.command('export').description('Export data')
-  exp.command('contacts').action(() => {
-    const { db, config, fmt } = getCtx()
-    const rows = (db.query('SELECT * FROM contacts').all() as any[]).map(c => contactToRow(c, config))
+  exp.command('contacts').action(async () => {
+    const { db, config, fmt } = await getCtx()
+    const rows = (await db.select().from(schema.contacts)).map(c => contactToRow(c, config))
     console.log(formatOutput(rows, fmt, config))
   })
-  exp.command('companies').action(() => {
-    const { db, config, fmt } = getCtx()
-    const rows = (db.query('SELECT * FROM companies').all() as any[]).map(c => companyToRow(c, config))
+  exp.command('companies').action(async () => {
+    const { db, config, fmt } = await getCtx()
+    const rows = (await db.select().from(schema.companies)).map(c => companyToRow(c, config))
     console.log(formatOutput(rows, fmt, config))
   })
-  exp.command('deals').action(() => {
-    const { db, config, fmt } = getCtx()
-    const rows = (db.query('SELECT * FROM deals').all() as any[]).map(d => dealToRow(d, config))
+  exp.command('deals').action(async () => {
+    const { db, config, fmt } = await getCtx()
+    const rows = (await db.select().from(schema.deals)).map(d => dealToRow(d, config))
     console.log(formatOutput(rows, fmt, config))
   })
-  exp.command('all').action(() => {
-    const { db, config, fmt } = getCtx()
+  exp.command('all').action(async () => {
+    const { db, config, fmt } = await getCtx()
     const data = {
-      contacts: (db.query('SELECT * FROM contacts').all() as any[]).map(c => contactToRow(c, config)),
-      companies: (db.query('SELECT * FROM companies').all() as any[]).map(c => companyToRow(c, config)),
-      deals: (db.query('SELECT * FROM deals').all() as any[]).map(d => dealToRow(d, config)),
-      activities: (db.query('SELECT * FROM activities').all() as any[]).map(a => activityToRow(a)),
+      contacts: (await db.select().from(schema.contacts)).map(c => contactToRow(c, config)),
+      companies: (await db.select().from(schema.companies)).map(c => companyToRow(c, config)),
+      deals: (await db.select().from(schema.deals)).map(d => dealToRow(d, config)),
+      activities: (await db.select().from(schema.activities)).map(a => activityToRow(a)),
     }
     if (fmt === 'json') console.log(JSON.stringify(data, null, 2))
     else console.log(formatOutput(Object.entries(data).map(([k, v]) => ({ type: k, count: v.length })), fmt, config))
@@ -190,8 +208,8 @@ function splitField(val: string | undefined): string[] {
   return val.split(',').map(s => s.trim()).filter(Boolean)
 }
 
-function findContactByEmail(db: any, email: string): any | null {
-  const all = db.query('SELECT * FROM contacts').all() as any[]
+async function findContactByEmail(db: DB, email: string): Promise<any | null> {
+  const all = await db.select().from(schema.contacts)
   for (const c of all) {
     const emails: string[] = safeJSON(c.emails)
     if (emails.some((e: string) => e.toLowerCase() === email.toLowerCase())) return c

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,13 +1,15 @@
+import { eq, sql } from 'drizzle-orm'
 import type { Command } from 'commander'
 import { getCtx } from '../lib/helpers'
 import { formatOutput, safeJSON, activityToRow, dealToRow } from '../format'
+import * as schema from '../drizzle-schema'
 
 export function registerReportCommands(program: Command) {
   const cmd = program.command('report').description('Reports')
 
-  cmd.command('pipeline').action(() => {
-    const { db, config, fmt } = getCtx()
-    const deals = db.query('SELECT * FROM deals').all() as any[]
+  cmd.command('pipeline').action(async () => {
+    const { db, config, fmt } = await getCtx()
+    const deals = await db.select().from(schema.deals)
     const summary = config.pipeline.stages.map(stage => ({
       stage,
       count: deals.filter(d => d.stage === stage).length,
@@ -22,9 +24,9 @@ export function registerReportCommands(program: Command) {
   cmd.command('activity')
     .option('--by <field>', 'Group by (type or contact)')
     .option('--period <period>', 'Time period (e.g. 7d, 30d)')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let activities = db.query('SELECT * FROM activities').all() as any[]
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let activities = await db.select().from(schema.activities)
       if (opts.period) {
         const cutoff = periodToDate(opts.period)
         if (cutoff) activities = activities.filter(a => a.created_at >= cutoff)
@@ -37,11 +39,13 @@ export function registerReportCommands(program: Command) {
       }
       let data: any[]
       if (groupBy === 'contact') {
-        data = Object.entries(groups).map(([contact, count]) => {
+        const dataPromises = Object.entries(groups).map(async ([contact, count]) => {
           if (contact === 'none') return { contact: '(none)', count }
-          const ct = db.query('SELECT name FROM contacts WHERE id = ?').get(contact) as any
+          const results = await db.select({ name: schema.contacts.name }).from(schema.contacts).where(eq(schema.contacts.id, contact))
+          const ct = results[0]
           return { contact: ct?.name || contact, count }
         })
+        data = await Promise.all(dataPromises)
       } else {
         data = Object.entries(groups).map(([type, count]) => ({ type, count }))
       }
@@ -52,25 +56,25 @@ export function registerReportCommands(program: Command) {
   cmd.command('stale')
     .option('--days <n>', 'Days threshold', '30')
     .option('--type <type>', 'Entity type (contact or deal)')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
       const days = Number(opts.days)
       const cutoff = new Date(Date.now() - days * 86400000).toISOString()
       const results: any[] = []
       if (!opts.type || opts.type === 'contact') {
-        const contacts = db.query('SELECT * FROM contacts').all() as any[]
+        const contacts = await db.select().from(schema.contacts)
         for (const c of contacts) {
-          const lastActivity = db.query('SELECT MAX(created_at) as last FROM activities WHERE contact = ?').get(c.id) as any
+          const lastActivity = (await db.all(sql`SELECT MAX(created_at) as last FROM activities WHERE contact = ${c.id}`) as any[])[0]
           if (!lastActivity?.last || lastActivity.last < cutoff) {
             results.push({ type: 'contact', id: c.id, name: c.name, last_activity: lastActivity?.last || null })
           }
         }
       }
       if (!opts.type || opts.type === 'deal') {
-        const deals = db.query('SELECT * FROM deals').all() as any[]
+        const deals = await db.select().from(schema.deals)
         for (const d of deals) {
           if (d.stage === 'closed-won' || d.stage === 'closed-lost') continue
-          const lastActivity = db.query('SELECT MAX(created_at) as last FROM activities WHERE deal = ?').get(d.id) as any
+          const lastActivity = (await db.all(sql`SELECT MAX(created_at) as last FROM activities WHERE deal = ${d.id}`) as any[])[0]
           const lastTouch = lastActivity?.last || d.created_at
           if (lastTouch < cutoff) {
             results.push({ type: 'deal', id: d.id, title: d.title, last_activity: lastActivity?.last || null })
@@ -85,14 +89,14 @@ export function registerReportCommands(program: Command) {
       }
     })
 
-  cmd.command('conversion').action(() => {
-    const { db, config, fmt } = getCtx()
+  cmd.command('conversion').action(async () => {
+    const { db, config, fmt } = await getCtx()
     const stages = config.pipeline.stages
-    const activities = db.query("SELECT * FROM activities WHERE type = 'stage-change'").all() as any[]
+    const activities = await db.select().from(schema.activities).where(eq(schema.activities.type, 'stage-change'))
     const stageEntries: Record<string, Set<string>> = {}
     const stageExits: Record<string, Set<string>> = {}
     for (const s of stages) { stageEntries[s] = new Set(); stageExits[s] = new Set() }
-    const deals = db.query('SELECT * FROM deals').all() as any[]
+    const deals = await db.select().from(schema.deals)
     for (const d of deals) {
       const dealActivities = activities.filter(a => a.deal === d.id)
       if (dealActivities.length === 0) {
@@ -120,16 +124,19 @@ export function registerReportCommands(program: Command) {
     else console.log(formatOutput(data, fmt, config))
   })
 
-  cmd.command('velocity').action(() => {
-    const { db, config, fmt } = getCtx()
+  cmd.command('velocity').action(async () => {
+    const { db, config, fmt } = await getCtx()
     const stages = config.pipeline.stages
-    const activities = db.query("SELECT * FROM activities WHERE type = 'stage-change' ORDER BY created_at ASC").all() as any[]
+    const activities = await db.select().from(schema.activities)
+      .where(eq(schema.activities.type, 'stage-change'))
+      .orderBy(schema.activities.created_at)
     const stageTimes: Record<string, number[]> = {}
     for (const s of stages) stageTimes[s] = []
     const dealIds = [...new Set(activities.map(a => a.deal))]
     for (const did of dealIds) {
       const dealActs = activities.filter(a => a.deal === did)
-      const deal = db.query('SELECT * FROM deals WHERE id = ?').get(did) as any
+      const dealResults = await db.select().from(schema.deals).where(eq(schema.deals.id, did!))
+      const deal = dealResults[0]
       if (!deal) continue
       let prevTime = new Date(deal.created_at).getTime()
       const first = dealActs[0]
@@ -158,9 +165,9 @@ export function registerReportCommands(program: Command) {
 
   cmd.command('forecast')
     .option('--period <period>', 'Filter by expected close month (YYYY-MM) or days (30d)')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let deals = db.query('SELECT * FROM deals').all() as any[]
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let deals = await db.select().from(schema.deals)
       deals = deals.filter(d => d.stage !== 'closed-won' && d.stage !== 'closed-lost')
       if (opts.period) {
         if (opts.period.match(/^\d{4}-\d{2}$/)) {
@@ -185,9 +192,9 @@ export function registerReportCommands(program: Command) {
 
   cmd.command('won')
     .option('--period <period>', 'Time period (e.g. 30d)')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let deals = (db.query("SELECT * FROM deals WHERE stage = 'closed-won'").all() as any[])
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let deals = await db.select().from(schema.deals).where(eq(schema.deals.stage, 'closed-won'))
       if (opts.period) {
         const cutoff = periodToDate(opts.period)
         if (cutoff) deals = deals.filter(d => d.updated_at >= cutoff)
@@ -200,22 +207,23 @@ export function registerReportCommands(program: Command) {
   cmd.command('lost')
     .option('--reasons', 'Show loss reasons')
     .option('--period <period>', 'Time period')
-    .action((opts) => {
-      const { db, config, fmt } = getCtx()
-      let deals = (db.query("SELECT * FROM deals WHERE stage = 'closed-lost'").all() as any[])
+    .action(async (opts) => {
+      const { db, config, fmt } = await getCtx()
+      let deals = await db.select().from(schema.deals).where(eq(schema.deals.stage, 'closed-lost'))
       if (opts.period) {
         const cutoff = periodToDate(opts.period)
         if (cutoff) deals = deals.filter(d => d.updated_at >= cutoff)
       }
-      const data = deals.map(d => {
+      const data = await Promise.all(deals.map(async d => {
         const row = dealToRow(d, config) as any
         if (opts.reasons) {
-          const act = db.query("SELECT body FROM activities WHERE deal = ? AND type = 'stage-change' AND body LIKE '%closed-lost%'").get(d.id) as any
+          const actResults = await db.all(sql`SELECT body FROM activities WHERE deal = ${d.id} AND type = 'stage-change' AND body LIKE '%closed-lost%'`) as any[]
+          const act = actResults[0]
           const reason = act?.body?.split('|').slice(1).map((s: string) => s.trim()).join(', ') || ''
           row.reason = reason
         }
         return row
-      })
+      }))
       if (fmt === 'json') console.log(JSON.stringify(data, null, 2))
       else console.log(formatOutput(data, fmt, config))
     })

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,29 +1,32 @@
+import { eq, sql } from 'drizzle-orm'
 import type { Command } from 'commander'
 import { getCtx, levenshtein } from '../lib/helpers'
 import { formatOutput, contactToRow, companyToRow, dealToRow, activityToRow, safeJSON } from '../format'
 import { rebuildSearchIndex } from '../db'
+import type { DB } from '../db'
+import * as schema from '../drizzle-schema'
 
 export function registerSearchCommands(program: Command) {
   program.command('search')
     .description('Full-text search')
     .argument('<query>')
     .option('--type <type>')
-    .action((query, opts) => {
-      const { db, config, fmt } = getCtx()
+    .action(async (query, opts) => {
+      const { db, config, fmt } = await getCtx()
       let results: any[] = []
       try {
-        const ftsRows = db.query('SELECT * FROM search_index WHERE content MATCH ?').all(query) as any[]
+        const ftsRows = await db.all(sql`SELECT * FROM search_index WHERE content MATCH ${query}`) as any[]
         for (const fr of ftsRows) {
           if (opts.type && fr.entity_type !== opts.type) continue
-          const entity = lookupEntity(db, fr.entity_type, fr.entity_id, config)
+          const entity = await lookupEntity(db, fr.entity_type, fr.entity_id, config)
           if (entity) results.push(entity)
         }
       } catch {
         // FTS5 match can fail on certain queries, fall back to LIKE
-        const likeRows = db.query('SELECT * FROM search_index WHERE content LIKE ?').all(`%${query}%`) as any[]
+        const likeRows = await db.all(sql`SELECT * FROM search_index WHERE content LIKE ${'%' + query + '%'}`) as any[]
         for (const fr of likeRows) {
           if (opts.type && fr.entity_type !== opts.type) continue
-          const entity = lookupEntity(db, fr.entity_type, fr.entity_id, config)
+          const entity = await lookupEntity(db, fr.entity_type, fr.entity_id, config)
           if (entity) results.push(entity)
         }
       }
@@ -46,11 +49,11 @@ export function registerSearchCommands(program: Command) {
     .argument('<query>')
     .option('--type <type>')
     .option('--limit <n>')
-    .action((query, opts) => {
-      const { db, config, fmt } = getCtx()
+    .action(async (query, opts) => {
+      const { db, config, fmt } = await getCtx()
       const queryWords = query.toLowerCase().split(/\s+/)
       const allEntities: any[] = []
-      const indexRows = db.query('SELECT * FROM search_index').all() as any[]
+      const indexRows = await db.all(sql`SELECT * FROM search_index`) as any[]
       for (const row of indexRows) {
         if (opts.type && row.entity_type !== opts.type) continue
         if (row.entity_type === 'activity') continue
@@ -64,7 +67,8 @@ export function registerSearchCommands(program: Command) {
       allEntities.sort((a, b) => b.score - a.score)
       let limited = allEntities
       if (opts.limit) limited = limited.slice(0, Number(opts.limit))
-      const results = limited.map(r => lookupEntity(db, r.entity_type, r.entity_id, config)).filter(Boolean) as any[]
+      const resultPromises = limited.map(r => lookupEntity(db, r.entity_type, r.entity_id, config))
+      const results = (await Promise.all(resultPromises)).filter(Boolean) as any[]
       if (fmt === 'json') console.log(JSON.stringify(results, null, 2))
       else {
         if (results.length === 0) { console.log(''); return }
@@ -74,44 +78,48 @@ export function registerSearchCommands(program: Command) {
     })
 
   const idx = program.command('index').description('Search index management')
-  idx.command('status').action(() => {
-    const { db } = getCtx()
+  idx.command('status').action(async () => {
+    const { db } = await getCtx()
+    const countRows = await db.all(sql`SELECT entity_type, COUNT(*) as cnt FROM search_index GROUP BY entity_type`) as any[]
     const counts: Record<string, number> = {}
-    const rows = db.query('SELECT entity_type, COUNT(*) as cnt FROM search_index GROUP BY entity_type').all() as any[]
-    for (const r of rows) counts[r.entity_type] = r.cnt
-    const contactCount = db.query('SELECT COUNT(*) as cnt FROM contacts').get() as any
-    const companyCount = db.query('SELECT COUNT(*) as cnt FROM companies').get() as any
-    const dealCount = db.query('SELECT COUNT(*) as cnt FROM deals').get() as any
+    for (const r of countRows) counts[r.entity_type] = r.cnt
+    const contactCount = (await db.select({ cnt: sql<number>`COUNT(*)` }).from(schema.contacts))[0]
+    const companyCount = (await db.select({ cnt: sql<number>`COUNT(*)` }).from(schema.companies))[0]
+    const dealCount = (await db.select({ cnt: sql<number>`COUNT(*)` }).from(schema.deals))[0]
     console.log(`contacts: ${contactCount.cnt} (indexed: ${counts.contact || 0})`)
     console.log(`companies: ${companyCount.cnt} (indexed: ${counts.company || 0})`)
     console.log(`deals: ${dealCount.cnt} (indexed: ${counts.deal || 0})`)
   })
 
-  idx.command('rebuild').action(() => {
-    const { db } = getCtx()
-    rebuildSearchIndex(db)
+  idx.command('rebuild').action(async () => {
+    const { db } = await getCtx()
+    await rebuildSearchIndex(db)
     console.log('Index rebuilt')
   })
 }
 
-function lookupEntity(db: any, entityType: string, id: string, config: any): any | null {
+async function lookupEntity(db: DB, entityType: string, id: string, config: any): Promise<any | null> {
   if (entityType === 'contact') {
-    const c = db.query('SELECT * FROM contacts WHERE id = ?').get(id)
+    const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, id))
+    const c = results[0]
     if (!c) return null
     return { type: 'contact', ...contactToRow(c, config) }
   }
   if (entityType === 'company') {
-    const c = db.query('SELECT * FROM companies WHERE id = ?').get(id)
+    const results = await db.select().from(schema.companies).where(eq(schema.companies.id, id))
+    const c = results[0]
     if (!c) return null
     return { type: 'company', ...companyToRow(c, config) }
   }
   if (entityType === 'deal') {
-    const d = db.query('SELECT * FROM deals WHERE id = ?').get(id)
+    const results = await db.select().from(schema.deals).where(eq(schema.deals.id, id))
+    const d = results[0]
     if (!d) return null
     return { type: 'deal', ...dealToRow(d, config) }
   }
   if (entityType === 'activity') {
-    const a = db.query('SELECT * FROM activities WHERE id = ?').get(id)
+    const results = await db.select().from(schema.activities).where(eq(schema.activities.id, id))
+    const a = results[0]
     if (!a) return null
     const row = activityToRow(a)
     return { entity_type: 'activity', ...row }

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -1,53 +1,76 @@
+import { eq, sql } from 'drizzle-orm'
 import type { Command } from 'commander'
 import { getCtx, die, now } from '../lib/helpers'
 import { resolveEntity } from '../resolve'
 import { safeJSON, formatOutput } from '../format'
+import type { DB } from '../db'
+import * as schema from '../drizzle-schema'
 
 export function registerTagCommands(program: Command) {
   program.command('tag')
     .description('Tag an entity or list tags')
     .argument('[args...]')
     .option('--type <type>')
-    .action((args: string[], opts) => {
+    .action(async (args: string[], opts) => {
       if (args[0] === 'list') return tagList(opts)
       if (args.length < 2) die('Error: usage: tag <ref> <tags...>')
       const ref = args[0]
       const tags = args.slice(1)
-      const { db, config } = getCtx()
-      const resolved = resolveEntity(db, ref, config)
+      const { db, config } = await getCtx()
+      const resolved = await resolveEntity(db, ref, config)
       if (!resolved) die(`Error: entity not found: ${ref}`)
       const { type, entity } = resolved
-      const table = type === 'contact' ? 'contacts' : type === 'company' ? 'companies' : 'deals'
       const existing: string[] = safeJSON(entity.tags)
       for (const t of tags) { if (!existing.includes(t)) existing.push(t) }
-      db.run(`UPDATE ${table} SET tags=?,updated_at=? WHERE id=?`, [JSON.stringify(existing), now(), entity.id])
+      if (type === 'contact') {
+        await db.update(schema.contacts).set({ tags: JSON.stringify(existing), updated_at: now() }).where(eq(schema.contacts.id, entity.id))
+      } else if (type === 'company') {
+        await db.update(schema.companies).set({ tags: JSON.stringify(existing), updated_at: now() }).where(eq(schema.companies.id, entity.id))
+      } else {
+        await db.update(schema.deals).set({ tags: JSON.stringify(existing), updated_at: now() }).where(eq(schema.deals.id, entity.id))
+      }
     })
 
   program.command('untag')
     .description('Remove tags from an entity')
     .argument('<ref>')
     .argument('<tags...>')
-    .action((ref: string, tags: string[]) => {
-      const { db, config } = getCtx()
-      const resolved = resolveEntity(db, ref, config)
+    .action(async (ref: string, tags: string[]) => {
+      const { db, config } = await getCtx()
+      const resolved = await resolveEntity(db, ref, config)
       if (!resolved) die(`Error: entity not found: ${ref}`)
       const { type, entity } = resolved
-      const table = type === 'contact' ? 'contacts' : type === 'company' ? 'companies' : 'deals'
       let existing: string[] = safeJSON(entity.tags)
       for (const t of tags) existing = existing.filter(v => v !== t)
-      db.run(`UPDATE ${table} SET tags=?,updated_at=? WHERE id=?`, [JSON.stringify(existing), now(), entity.id])
+      if (type === 'contact') {
+        await db.update(schema.contacts).set({ tags: JSON.stringify(existing), updated_at: now() }).where(eq(schema.contacts.id, entity.id))
+      } else if (type === 'company') {
+        await db.update(schema.companies).set({ tags: JSON.stringify(existing), updated_at: now() }).where(eq(schema.companies.id, entity.id))
+      } else {
+        await db.update(schema.deals).set({ tags: JSON.stringify(existing), updated_at: now() }).where(eq(schema.deals.id, entity.id))
+      }
     })
 }
 
-function tagList(opts: { type?: string }) {
-  const { db, config, fmt } = getCtx()
+async function tagList(opts: { type?: string }) {
+  const { db, config, fmt } = await getCtx()
   const tagMap: Record<string, number> = {}
-  const tables: { name: string; type: string }[] = []
-  if (!opts.type || opts.type === 'contact') tables.push({ name: 'contacts', type: 'contact' })
-  if (!opts.type || opts.type === 'company') tables.push({ name: 'companies', type: 'company' })
-  if (!opts.type || opts.type === 'deal') tables.push({ name: 'deals', type: 'deal' })
-  for (const t of tables) {
-    const rows = db.query(`SELECT tags FROM ${t.name}`).all() as any[]
+  if (!opts.type || opts.type === 'contact') {
+    const rows = await db.select({ tags: schema.contacts.tags }).from(schema.contacts)
+    for (const r of rows) {
+      const tags: string[] = safeJSON(r.tags)
+      for (const tag of tags) tagMap[tag] = (tagMap[tag] || 0) + 1
+    }
+  }
+  if (!opts.type || opts.type === 'company') {
+    const rows = await db.select({ tags: schema.companies.tags }).from(schema.companies)
+    for (const r of rows) {
+      const tags: string[] = safeJSON(r.tags)
+      for (const tag of tags) tagMap[tag] = (tagMap[tag] || 0) + 1
+    }
+  }
+  if (!opts.type || opts.type === 'deal') {
+    const rows = await db.select({ tags: schema.deals.tags }).from(schema.deals)
     for (const r of rows) {
       const tags: string[] = safeJSON(r.tags)
       for (const tag of tags) tagMap[tag] = (tagMap[tag] || 0) + 1

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,8 +1,13 @@
-import { Database } from 'bun:sqlite'
+import { createClient } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { sql } from 'drizzle-orm'
 import { mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
+import * as schema from './drizzle-schema'
 
-const SCHEMA = `
+export type DB = ReturnType<typeof drizzle<typeof schema>>
+
+const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS contacts (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
@@ -64,50 +69,61 @@ CREATE TABLE IF NOT EXISTS activities (
 CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts5(
   entity_type, entity_id, content
 );
-`;
+`
 
-export function openDB(dbPath: string): Database {
+export async function openDB(dbPath: string): Promise<DB> {
   mkdirSync(dirname(dbPath), { recursive: true })
-  const db = new Database(dbPath, { create: true })
-  db.exec('PRAGMA journal_mode=WAL')
-  db.exec('PRAGMA foreign_keys=ON')
-  db.exec(SCHEMA)
+  const client = createClient({ url: `file:${dbPath}` })
+  const db = drizzle(client, { schema })
+
+  // Initialize schema: execute each statement separately since libSQL
+  // doesn't support multi-statement exec natively
+  const statements = SCHEMA_SQL.split(';')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+  for (const stmt of statements) {
+    await client.execute(stmt)
+  }
+
+  await client.execute('PRAGMA journal_mode=WAL')
+  await client.execute('PRAGMA foreign_keys=ON')
+
   return db
 }
 
-export function upsertSearchIndex(db: Database, entityType: string, entityId: string, content: string): void {
-  db.run('DELETE FROM search_index WHERE entity_id = ?', [entityId])
-  db.run('INSERT INTO search_index (entity_type, entity_id, content) VALUES (?, ?, ?)', [entityType, entityId, content])
+export async function upsertSearchIndex(db: DB, entityType: string, entityId: string, content: string): Promise<void> {
+  await db.run(sql`DELETE FROM search_index WHERE entity_id = ${entityId}`)
+  await db.run(sql`INSERT INTO search_index (entity_type, entity_id, content) VALUES (${entityType}, ${entityId}, ${content})`)
 }
 
-export function removeSearchIndex(db: Database, entityId: string): void {
-  db.run('DELETE FROM search_index WHERE entity_id = ?', [entityId])
+export async function removeSearchIndex(db: DB, entityId: string): Promise<void> {
+  await db.run(sql`DELETE FROM search_index WHERE entity_id = ${entityId}`)
 }
 
-export function rebuildSearchIndex(db: Database): void {
-  db.run('DELETE FROM search_index')
+export async function rebuildSearchIndex(db: DB): Promise<void> {
+  await db.run(sql`DELETE FROM search_index`)
 
-  const contacts = db.query('SELECT * FROM contacts').all() as any[]
-  for (const c of contacts) {
+  const allContacts = await db.select().from(schema.contacts)
+  for (const c of allContacts) {
     const content = [c.name, c.emails, c.phones, c.linkedin, c.x, c.bluesky, c.telegram, c.tags, c.custom_fields].filter(Boolean).join(' ')
-    db.run('INSERT INTO search_index (entity_type, entity_id, content) VALUES (?, ?, ?)', ['contact', c.id, content])
+    await db.run(sql`INSERT INTO search_index (entity_type, entity_id, content) VALUES (${'contact'}, ${c.id}, ${content})`)
   }
 
-  const companies = db.query('SELECT * FROM companies').all() as any[]
-  for (const co of companies) {
+  const allCompanies = await db.select().from(schema.companies)
+  for (const co of allCompanies) {
     const content = [co.name, co.websites, co.phones, co.tags, co.custom_fields].filter(Boolean).join(' ')
-    db.run('INSERT INTO search_index (entity_type, entity_id, content) VALUES (?, ?, ?)', ['company', co.id, content])
+    await db.run(sql`INSERT INTO search_index (entity_type, entity_id, content) VALUES (${'company'}, ${co.id}, ${content})`)
   }
 
-  const deals = db.query('SELECT * FROM deals').all() as any[]
-  for (const d of deals) {
+  const allDeals = await db.select().from(schema.deals)
+  for (const d of allDeals) {
     const content = [d.title, d.stage, d.tags, d.custom_fields].filter(Boolean).join(' ')
-    db.run('INSERT INTO search_index (entity_type, entity_id, content) VALUES (?, ?, ?)', ['deal', d.id, content])
+    await db.run(sql`INSERT INTO search_index (entity_type, entity_id, content) VALUES (${'deal'}, ${d.id}, ${content})`)
   }
 
-  const activities = db.query('SELECT * FROM activities').all() as any[]
-  for (const a of activities) {
+  const allActivities = await db.select().from(schema.activities)
+  for (const a of allActivities) {
     const content = [a.type, a.body, a.custom_fields].filter(Boolean).join(' ')
-    db.run('INSERT INTO search_index (entity_type, entity_id, content) VALUES (?, ?, ?)', ['activity', a.id, content])
+    await db.run(sql`INSERT INTO search_index (entity_type, entity_id, content) VALUES (${'activity'}, ${a.id}, ${content})`)
   }
 }

--- a/src/drizzle-schema.ts
+++ b/src/drizzle-schema.ts
@@ -1,0 +1,54 @@
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
+
+export const contacts = sqliteTable('contacts', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  emails: text('emails').notNull().default('[]'),
+  phones: text('phones').notNull().default('[]'),
+  companies: text('companies').notNull().default('[]'),
+  linkedin: text('linkedin'),
+  x: text('x'),
+  bluesky: text('bluesky'),
+  telegram: text('telegram'),
+  tags: text('tags').notNull().default('[]'),
+  custom_fields: text('custom_fields').notNull().default('{}'),
+  created_at: text('created_at').notNull(),
+  updated_at: text('updated_at').notNull(),
+})
+
+export const companies = sqliteTable('companies', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  websites: text('websites').notNull().default('[]'),
+  phones: text('phones').notNull().default('[]'),
+  tags: text('tags').notNull().default('[]'),
+  custom_fields: text('custom_fields').notNull().default('{}'),
+  created_at: text('created_at').notNull(),
+  updated_at: text('updated_at').notNull(),
+})
+
+export const deals = sqliteTable('deals', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  value: integer('value'),
+  stage: text('stage').notNull(),
+  contacts: text('contacts').notNull().default('[]'),
+  company: text('company'),
+  expected_close: text('expected_close'),
+  probability: integer('probability'),
+  tags: text('tags').notNull().default('[]'),
+  custom_fields: text('custom_fields').notNull().default('{}'),
+  created_at: text('created_at').notNull(),
+  updated_at: text('updated_at').notNull(),
+})
+
+export const activities = sqliteTable('activities', {
+  id: text('id').primaryKey(),
+  type: text('type').notNull(),
+  body: text('body').notNull().default(''),
+  contact: text('contact'),
+  company: text('company'),
+  deal: text('deal'),
+  custom_fields: text('custom_fields').notNull().default('{}'),
+  created_at: text('created_at').notNull(),
+})

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,10 +1,12 @@
 import { ulid } from 'ulid'
-import type { Database } from 'bun:sqlite'
+import { eq, sql } from 'drizzle-orm'
+import type { DB } from '../db'
 import { loadConfig, type CRMConfig } from '../config'
 import { openDB, upsertSearchIndex } from '../db'
 import { normalizePhone, tryNormalizePhone, normalizeWebsite, normalizeSocialHandle, formatPhone } from '../normalize'
 import { safeJSON, contactToRow, companyToRow, dealToRow, activityToRow } from '../format'
 import { resolveCompanyForLink } from '../resolve'
+import * as schema from '../drizzle-schema'
 
 // ── Global option extraction ──
 const rawArgv = process.argv.slice(2)
@@ -18,9 +20,9 @@ for (let i = 0; i < rawArgv.length; i++) {
   cleanArgv.push(rawArgv[i])
 }
 
-export function getCtx() {
+export async function getCtx() {
   const config = loadConfig({ configPath: gConfig, dbPath: gDb, format: gFmt })
-  const db = openDB(config.database.path)
+  const db = await openDB(config.database.path)
   return { config, db, fmt: config.defaults.format }
 }
 
@@ -38,28 +40,28 @@ export function parseKV(arr: string[]): Record<string, string> {
   return r
 }
 
-export function getOrCreateCompany(db: Database, ref: string, config: CRMConfig): string {
-  const co = resolveCompanyForLink(db, ref, config)
+export async function getOrCreateCompany(db: DB, ref: string, config: CRMConfig): Promise<string> {
+  const co = await resolveCompanyForLink(db, ref, config)
   if (co) return co.name
   const cid = makeId('co')
   const n = now()
-  db.run('INSERT INTO companies (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)', [cid, ref, n, n])
-  upsertSearchIndex(db, 'company', cid, ref)
+  await db.insert(schema.companies).values({ id: cid, name: ref, websites: '[]', phones: '[]', tags: '[]', custom_fields: '{}', created_at: n, updated_at: n })
+  await upsertSearchIndex(db, 'company', cid, ref)
   return ref
 }
 
-export function getOrCreateCompanyId(db: Database, ref: string, config: CRMConfig): string {
-  const co = resolveCompanyForLink(db, ref, config)
+export async function getOrCreateCompanyId(db: DB, ref: string, config: CRMConfig): Promise<string> {
+  const co = await resolveCompanyForLink(db, ref, config)
   if (co) return co.id
   const cid = makeId('co')
   const n = now()
-  db.run('INSERT INTO companies (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)', [cid, ref, n, n])
-  upsertSearchIndex(db, 'company', cid, ref)
+  await db.insert(schema.companies).values({ id: cid, name: ref, websites: '[]', phones: '[]', tags: '[]', custom_fields: '{}', created_at: n, updated_at: n })
+  await upsertSearchIndex(db, 'company', cid, ref)
   return cid
 }
 
-export function checkDupeEmail(db: Database, email: string, excludeId?: string) {
-  const all = db.query('SELECT * FROM contacts').all() as any[]
+export async function checkDupeEmail(db: DB, email: string, excludeId?: string) {
+  const all = await db.select().from(schema.contacts)
   for (const c of all) {
     if (excludeId && c.id === excludeId) continue
     const emails: string[] = safeJSON(c.emails)
@@ -68,8 +70,10 @@ export function checkDupeEmail(db: Database, email: string, excludeId?: string) 
   }
 }
 
-export function checkDupePhone(db: Database, phone: string, table: string, excludeId?: string) {
-  const all = db.query(`SELECT * FROM ${table}`).all() as any[]
+export async function checkDupePhone(db: DB, phone: string, table: string, excludeId?: string) {
+  const all = table === 'contacts'
+    ? await db.select().from(schema.contacts)
+    : await db.select().from(schema.companies)
   for (const c of all) {
     if (excludeId && c.id === excludeId) continue
     const phones: string[] = safeJSON(c.phones)
@@ -78,8 +82,8 @@ export function checkDupePhone(db: Database, phone: string, table: string, exclu
   }
 }
 
-export function checkDupeWebsite(db: Database, website: string, excludeId?: string) {
-  const all = db.query('SELECT * FROM companies').all() as any[]
+export async function checkDupeWebsite(db: DB, website: string, excludeId?: string) {
+  const all = await db.select().from(schema.companies)
   for (const co of all) {
     if (excludeId && co.id === excludeId) continue
     const websites: string[] = safeJSON(co.websites)
@@ -88,10 +92,12 @@ export function checkDupeWebsite(db: Database, website: string, excludeId?: stri
   }
 }
 
-export function checkDupeSocial(db: Database, platform: string, handle: string, excludeId?: string) {
-  const existing = db.query(`SELECT * FROM contacts WHERE ${platform} = ?`).get(handle) as any
-  if (existing && existing.id !== excludeId)
-    die(`Error: duplicate ${platform} handle "${handle}" — already belongs to ${existing.name} (${existing.id})`)
+export async function checkDupeSocial(db: DB, platform: string, handle: string, excludeId?: string) {
+  const col = platform as 'linkedin' | 'x' | 'bluesky' | 'telegram'
+  const existing = await db.select().from(schema.contacts).where(eq(schema.contacts[col], handle))
+  const match = existing[0]
+  if (match && match.id !== excludeId)
+    die(`Error: duplicate ${platform} handle "${handle}" — already belongs to ${match.name} (${match.id})`)
 }
 
 export function buildContactSearch(c: any): string {
@@ -107,46 +113,49 @@ export function buildDealSearch(d: any): string {
   return [d.title, d.stage, JSON.stringify(safeJSON(d.custom_fields)), d.tags].filter(Boolean).join(' ')
 }
 
-export function contactDetail(db: Database, c: any, config: CRMConfig): any {
+export async function contactDetail(db: DB, c: any, config: CRMConfig): Promise<any> {
   const row = contactToRow(c, config)
   const phones: string[] = safeJSON(c.phones)
   row._display_phones = phones.map(p => formatPhone(p, config.phone.display, config.phone.default_country))
-  const deals = db.query('SELECT * FROM deals').all() as any[]
-  row.deals = deals.filter(d => {
+  const allDeals = await db.select().from(schema.deals)
+  row.deals = allDeals.filter(d => {
     const contacts: string[] = safeJSON(d.contacts)
     return contacts.includes(c.id)
   }).map(d => ({ id: d.id, title: d.title, stage: d.stage, value: d.value }))
   return row
 }
 
-export function companyDetail(db: Database, co: any, config: CRMConfig): any {
+export async function companyDetail(db: DB, co: any, config: CRMConfig): Promise<any> {
   const row = companyToRow(co, config)
   const phones: string[] = safeJSON(co.phones)
   row._display_phones = phones.map(p => formatPhone(p, config.phone.display, config.phone.default_country))
-  const contacts = db.query('SELECT * FROM contacts').all() as any[]
-  row.contacts = contacts.filter(ct => {
+  const allContacts = await db.select().from(schema.contacts)
+  row.contacts = allContacts.filter(ct => {
     const companies: string[] = safeJSON(ct.companies)
     return companies.includes(co.name)
   }).map(ct => ({ id: ct.id, name: ct.name, emails: safeJSON(ct.emails) }))
-  const deals = db.query('SELECT * FROM deals WHERE company = ?').all(co.id) as any[]
-  row.deals = deals.map(d => ({ id: d.id, title: d.title, stage: d.stage, value: d.value }))
+  const allDeals = await db.select().from(schema.deals).where(eq(schema.deals.company, co.id))
+  row.deals = allDeals.map(d => ({ id: d.id, title: d.title, stage: d.stage, value: d.value }))
   return row
 }
 
-export function dealDetail(db: Database, d: any, config: CRMConfig): any {
+export async function dealDetail(db: DB, d: any, config: CRMConfig): Promise<any> {
   const row = dealToRow(d, config)
   const contactIds: string[] = safeJSON(d.contacts)
-  row.contacts = contactIds.map(cid => {
-    const ct = db.query('SELECT * FROM contacts WHERE id = ?').get(cid) as any
+  const contactPromises = contactIds.map(async cid => {
+    const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, cid))
+    const ct = results[0]
     return ct ? { id: ct.id, name: ct.name, emails: safeJSON(ct.emails) } : null
-  }).filter(Boolean)
+  })
+  row.contacts = (await Promise.all(contactPromises)).filter(Boolean)
   if (d.company) {
-    const co = db.query('SELECT * FROM companies WHERE id = ?').get(d.company) as any
+    const results = await db.select().from(schema.companies).where(eq(schema.companies.id, d.company))
+    const co = results[0]
     row.company = co ? { id: co.id, name: co.name } : null
   }
-  const stageChanges = db.query(
-    "SELECT * FROM activities WHERE deal = ? AND type = 'stage-change' ORDER BY created_at ASC"
-  ).all(d.id) as any[]
+  const stageChanges = await db.select().from(schema.activities)
+    .where(sql`${schema.activities.deal} = ${d.id} AND ${schema.activities.type} = 'stage-change'`)
+    .orderBy(schema.activities.created_at)
   const history: { stage: string; at: string }[] = []
   if (stageChanges.length > 0) {
     const m = stageChanges[0].body.match(/from (\S+) to/)

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,18 +1,21 @@
-import type { Database } from 'bun:sqlite'
+import { eq, sql } from 'drizzle-orm'
+import type { DB } from './db'
 import { normalizePhone, tryNormalizePhone, extractPhoneDigits, phoneMatchesByDigits, tryNormalizeWebsite, normalizeSocialHandle, tryExtractSocialHandle } from './normalize.ts'
 import { safeJSON } from './format.ts'
+import * as schema from './drizzle-schema'
 
-export function resolveContact(db: Database, ref: string, config?: any): any | null {
+export async function resolveContact(db: DB, ref: string, config?: any): Promise<any | null> {
   // By ID
   if (ref.startsWith('ct_')) {
-    return db.query('SELECT * FROM contacts WHERE id = ?').get(ref)
+    const results = await db.select().from(schema.contacts).where(eq(schema.contacts.id, ref))
+    return results[0] || null
   }
 
   // By email
   if (ref.includes('@') && !ref.includes('/')) {
     const handle = ref.startsWith('@') ? ref.slice(1) : ref
     // First try as email
-    const all = db.query('SELECT * FROM contacts').all() as any[]
+    const all = await db.select().from(schema.contacts)
     for (const c of all) {
       const emails: string[] = safeJSON(c.emails)
       if (emails.some((e) => e.toLowerCase() === ref.toLowerCase())) return c
@@ -27,15 +30,15 @@ export function resolveContact(db: Database, ref: string, config?: any): any | n
   // Try social URL extraction
   const extracted = tryExtractSocialHandle(ref)
   if (extracted) {
-    const col = extracted.platform
-    const c = db.query(`SELECT * FROM contacts WHERE ${col} = ?`).get(extracted.handle)
-    if (c) return c
+    const col = extracted.platform as 'linkedin' | 'x' | 'bluesky' | 'telegram'
+    const results = await db.select().from(schema.contacts).where(eq(schema.contacts[col], extracted.handle))
+    if (results[0]) return results[0]
   }
 
   // Try phone normalization
   const phoneNorm = tryNormalizePhone(ref, config?.phone?.default_country)
   if (phoneNorm) {
-    const all = db.query('SELECT * FROM contacts').all() as any[]
+    const all = await db.select().from(schema.contacts)
     for (const c of all) {
       const phones: string[] = safeJSON(c.phones)
       if (phones.includes(phoneNorm)) return c
@@ -45,7 +48,7 @@ export function resolveContact(db: Database, ref: string, config?: any): any | n
   // Try digit-based phone matching
   const digits = extractPhoneDigits(ref)
   if (digits.length >= 7) {
-    const all = db.query('SELECT * FROM contacts').all() as any[]
+    const all = await db.select().from(schema.contacts)
     for (const c of all) {
       const phones: string[] = safeJSON(c.phones)
       for (const p of phones) {
@@ -57,7 +60,7 @@ export function resolveContact(db: Database, ref: string, config?: any): any | n
   // Try as raw social handle (no URL)
   if (!ref.includes('.') && !ref.includes('/')) {
     const handle = ref.startsWith('@') ? ref.slice(1) : ref
-    const all = db.query('SELECT * FROM contacts').all() as any[]
+    const all = await db.select().from(schema.contacts)
     for (const c of all) {
       if (c.linkedin === handle || c.x === handle || c.bluesky === handle || c.telegram === handle) return c
     }
@@ -66,7 +69,7 @@ export function resolveContact(db: Database, ref: string, config?: any): any | n
   // Try social handle with dots (like bsky handles)
   {
     const handle = ref.startsWith('@') ? ref.slice(1) : ref
-    const all = db.query('SELECT * FROM contacts').all() as any[]
+    const all = await db.select().from(schema.contacts)
     for (const c of all) {
       if (c.linkedin === handle || c.x === handle || c.bluesky === handle || c.telegram === handle) return c
     }
@@ -75,14 +78,15 @@ export function resolveContact(db: Database, ref: string, config?: any): any | n
   return null
 }
 
-export function resolveCompany(db: Database, ref: string, config?: any): any | null {
+export async function resolveCompany(db: DB, ref: string, config?: any): Promise<any | null> {
   // By ID
   if (ref.startsWith('co_')) {
-    return db.query('SELECT * FROM companies WHERE id = ?').get(ref)
+    const results = await db.select().from(schema.companies).where(eq(schema.companies.id, ref))
+    return results[0] || null
   }
 
   // By website (normalize and check)
-  const all = db.query('SELECT * FROM companies').all() as any[]
+  const all = await db.select().from(schema.companies)
   const normalizedWeb = tryNormalizeWebsite(ref)
   if (normalizedWeb) {
     for (const co of all) {
@@ -119,37 +123,39 @@ export function resolveCompany(db: Database, ref: string, config?: any): any | n
   return null
 }
 
-export function resolveDeal(db: Database, ref: string): any | null {
+export async function resolveDeal(db: DB, ref: string): Promise<any | null> {
   if (ref.startsWith('dl_')) {
-    return db.query('SELECT * FROM deals WHERE id = ?').get(ref)
+    const results = await db.select().from(schema.deals).where(eq(schema.deals.id, ref))
+    return results[0] || null
   }
   return null
 }
 
-export function resolveEntity(db: Database, ref: string, config?: any): { type: string; entity: any } | null {
+export async function resolveEntity(db: DB, ref: string, config?: any): Promise<{ type: string; entity: any } | null> {
   // Try contact first
-  const contact = resolveContact(db, ref, config)
+  const contact = await resolveContact(db, ref, config)
   if (contact) return { type: 'contact', entity: contact }
 
   // Try company
-  const company = resolveCompany(db, ref, config)
+  const company = await resolveCompany(db, ref, config)
   if (company) return { type: 'company', entity: company }
 
   // Try deal
-  const deal = resolveDeal(db, ref)
+  const deal = await resolveDeal(db, ref)
   if (deal) return { type: 'deal', entity: deal }
 
   return null
 }
 
-export function resolveCompanyForLink(db: Database, ref: string, config?: any): any | null {
+export async function resolveCompanyForLink(db: DB, ref: string, config?: any): Promise<any | null> {
   // Try by ID
   if (ref.startsWith('co_')) {
-    return db.query('SELECT * FROM companies WHERE id = ?').get(ref)
+    const results = await db.select().from(schema.companies).where(eq(schema.companies.id, ref))
+    return results[0] || null
   }
 
   // Try by website
-  const all = db.query('SELECT * FROM companies').all() as any[]
+  const all = await db.select().from(schema.companies)
   const normalizedWeb = tryNormalizeWebsite(ref)
   if (normalizedWeb) {
     for (const co of all) {
@@ -166,6 +172,6 @@ export function resolveCompanyForLink(db: Database, ref: string, config?: any): 
   return null
 }
 
-export function resolveContactForLink(db: Database, ref: string, config?: any): any | null {
+export async function resolveContactForLink(db: DB, ref: string, config?: any): Promise<any | null> {
   return resolveContact(db, ref, config)
 }


### PR DESCRIPTION
## Summary

- **Replace bun:sqlite with libSQL + Drizzle ORM** as the database layer, per the "SQLite via libSQL + Drizzle ORM" specification
- **Add `src/drizzle-schema.ts`** with typed Drizzle table definitions for all four tables (contacts, companies, deals, activities)
- **Rewrite `src/db.ts`** to use `createClient()` from `@libsql/client` with `drizzle()` wrapper from `drizzle-orm/libsql`
- **Convert all 12 source files** that previously used raw SQL / `bun:sqlite` `Database` type to use Drizzle's typed query builder (`db.select()`, `db.insert()`, `db.update()`, `db.delete()`) and async patterns
- **Retain raw SQL** (via Drizzle's `sql` template tag) only for FTS5 virtual table operations (`search_index`), which Drizzle doesn't natively support

All existing dependencies (`drizzle-orm`, `drizzle-kit`, `@libsql/client`) were already in `package.json`. No new dependencies added.

## Test plan

- [x] All 341 existing tests pass with zero failures
- [x] No behavior changes -- this is a pure refactor of the database layer
- [x] FTS5 full-text search continues to work via raw SQL through Drizzle's `sql` template literals
- [x] Schema initialization (table creation, indexes, FTS5 virtual table) still runs on first `openDB()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)