### PR TITLE
fix: `crm mount` crashes under node — replace import.meta.dir + ship FUSE/NFS sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "bun build src/cli.ts --outdir dist --target node --format esm --define __PKG_VERSION__=\"'$(node -p \"require('./package.json').version\")'\" --external @libsql/client --external drizzle-orm --external commander --external libphonenumber-js --external normalize-url --external toml --external ulid",
+    "build": "bun build src/cli.ts --outdir dist --target node --format esm --define __PKG_VERSION__=\"'$(node -p \"require('./package.json').version\")'\" --external @libsql/client --external drizzle-orm --external commander --external libphonenumber-js --external normalize-url --external toml --external ulid && cp src/fuse-helper.c dist/fuse-helper.c && cp -r src/nfs-server dist/nfs-server",
     "crm": "bun run src/cli.ts",
     "check-types": "tsc --noEmit",
     "test": "bun test --timeout 30000",

--- a/src/commands/fuse.ts
+++ b/src/commands/fuse.ts
@@ -8,7 +8,29 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Directory holding the compiled bundle (or the source file in dev). Works
+// under both Node and Bun, unlike `import.meta.dir` which is Bun-only and
+// resolves to `undefined` under Node.
+const BUNDLE_DIR = dirname(fileURLToPath(import.meta.url))
+
+// Resolve an asset shipped with the package (fuse-helper.c, nfs-server/).
+// In bundle mode the build copies these into `dist/`, so they sit next to
+// cli.js. In source mode (running `bun run src/cli.ts`) BUNDLE_DIR is
+// `src/commands` and the assets live one level up, in `src/`.
+function resolveAsset(name: string): string | null {
+  for (const candidate of [
+    join(BUNDLE_DIR, name),
+    join(BUNDLE_DIR, '..', name),
+  ]) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
 
 import type { Command } from 'commander'
 
@@ -72,9 +94,9 @@ async function mountDarwin(
 
   if (!existsSync(nfsHelperPath)) {
     // Auto-compile the Rust NFS server
-    const nfsSrcDir = join(import.meta.dir, '..', 'nfs-server')
-    if (!existsSync(join(nfsSrcDir, 'Cargo.toml'))) {
-      die(`Error: NFS server source not found at ${nfsSrcDir}`)
+    const nfsSrcDir = resolveAsset('nfs-server')
+    if (!(nfsSrcDir && existsSync(join(nfsSrcDir, 'Cargo.toml')))) {
+      die('Error: NFS server source not found in package.')
     }
     ensureDir(join(homedir(), '.crm', 'bin'))
     const cargoPath =
@@ -244,10 +266,10 @@ async function mountLinux(
   const helperPath = join(homedir(), '.crm', 'bin', 'crm-fuse')
 
   if (!existsSync(helperPath)) {
-    const srcPath = join(import.meta.dir, '..', 'fuse-helper.c')
-    if (!existsSync(srcPath)) {
+    const srcPath = resolveAsset('fuse-helper.c')
+    if (!srcPath) {
       die(
-        'Error: FUSE helper not found. Install FUSE dependencies and rebuild, or use `crm export-fs` instead.',
+        'Error: FUSE helper source not found in package. Reinstall crm.cli or use `crm export-fs` instead.',
       )
     }
     ensureDir(join(homedir(), '.crm', 'bin'))


### PR DESCRIPTION
## Repro

On a fresh install with no pre-existing `~/.crm/bin/crm-fuse`:

```bash
$ npm install -g @dzhng/crm.cli
$ crm mount ~/crm
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at join (node:path:1269:7)
    at mountLinux (.../dist/cli.js:3414:21)
```

## Root cause

Two compounding bugs:

1. `dist/cli.js` runs under `#!/usr/bin/env node`, but `mountLinux` / `mountDarwin` call `join(import.meta.dir, '..', '<asset>')` to find the helper source. `import.meta.dir` is a **Bun-only** extension; under Node it's `undefined`, so `join` throws before the rest of the auto-compile path can run.

2. Even with a working path resolver, the auto-compile path can't find the source — `package.json#files` ships only `["dist", "README.md", "LICENSE"]`, so `src/fuse-helper.c` and `src/nfs-server/` aren't in the published npm tarball at all.

## Fix

- Replace `import.meta.dir` with `dirname(fileURLToPath(import.meta.url))`, which works under both Bun and Node.
- Add a `resolveAsset(name)` helper that looks for the asset in `BUNDLE_DIR/<name>` (bundle mode) and `BUNDLE_DIR/../<name>` (source mode), and use it in both `mountLinux` and `mountDarwin`.
- Extend the `build` script to copy `src/fuse-helper.c` and `src/nfs-server/` into `dist/`, so they sit next to the bundled `cli.js` and ship via the existing `"files": ["dist"]` entry. No `package.json#files` change needed — only one source of truth for what's published.

## Verification

- `bun run build` — clean.
- `bun run check-types` — clean.
- `test/fuse-smoke/smoke.ts` — 4/4 pass.
- `test/fuse.test.ts` — 3/4 pass; the 4th test (`fuse scenarios > full scenario`) times out at 5s, but it does the same on `main` without my changes (verified by stashing and re-running on main). Pre-existing test flakiness, not introduced by this PR.
- `test/scenarios/*` — same 8 timeouts on `main` and on this branch (also verified by switching). Unrelated.
- Repro after fix on a real sandbox (Debian, libfuse3-dev installed, no `~/.crm/bin/crm-fuse`):
  ```
  $ node dist/cli.js mount /tmp/test-fix
  Mounted at /tmp/test-fix (PID 4144017)
  $ ls /tmp/test-fix
  activities  companies  contacts  deals  llm.txt  ...
  ```

## Suggested follow-up (out of scope here)

`crm mount` errors with exit 1 when called against an already-mounted path — that's intentional, but it makes idempotent setup scripts clunky. A `--idempotent` (or just exit 0 + a stderr note when the mountpoint is already healthy) flag would let consumers drop their `mountpoint -q X || crm mount X` guards. Happy to follow up with a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)