### PR TITLE
feat: --allow-other flag for crm mount (fixes single-uid FUSE EACCES)

### DIFF
--- a/src/commands/fuse.ts
+++ b/src/commands/fuse.ts
@@ -259,9 +259,9 @@ async function mountLinux(
   config: {
     database: { path: string }
     pipeline: { stages: string[] }
-    mount: { readonly?: boolean }
+    mount: { readonly?: boolean; allow_other?: boolean }
   },
-  opts: { readonly?: boolean },
+  opts: { readonly?: boolean; allowOther?: boolean },
 ) {
   const helperPath = join(homedir(), '.crm', 'bin', 'crm-fuse')
 
@@ -325,6 +325,12 @@ async function mountLinux(
   const fuseArgs = ['-f', mp, '--', socketPath]
   if (opts.readonly || config.mount.readonly) {
     fuseArgs.unshift('-o', 'ro')
+  }
+  if (opts.allowOther || config.mount.allow_other) {
+    // `user_allow_other` must be enabled in /etc/fuse.conf for this to work
+    // when the mount is invoked by a non-root user. The mount call will fail
+    // loudly if it isn't.
+    fuseArgs.unshift('-o', 'allow_other')
   }
 
   const fuseProc = spawn(helperPath, fuseArgs, {
@@ -437,6 +443,10 @@ export function registerFuseCommands(program: Command) {
     .description('Mount CRM as virtual filesystem')
     .argument('[mountpoint]', 'Mount point directory')
     .option('--readonly', 'Mount read-only')
+    .option(
+      '--allow-other',
+      'Allow processes running as a different uid (e.g. root) to access the mount. Linux-only; requires user_allow_other in /etc/fuse.conf when invoked by a non-root user.',
+    )
     .action(async (mountpoint, opts) => {
       const { config } = await getCtx()
       const mp = mountpoint || config.mount.default_path

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,13 @@ export interface CRMConfig {
   mount: {
     default_path: string
     readonly: boolean
+    /**
+     * Mount with `-o allow_other` so processes running as a different uid
+     * (e.g. root, container orchestrators) can read/write the FUSE filesystem.
+     * Requires `user_allow_other` in /etc/fuse.conf when the mount is invoked
+     * by a non-root user. Linux-only; ignored by the macOS NFS path.
+     */
+    allow_other: boolean
     max_recent_activity: number
     search_limit: number
   }
@@ -44,6 +51,7 @@ function defaultConfig(): CRMConfig {
     mount: {
       default_path: join(homedir(), 'crm'),
       readonly: false,
+      allow_other: false,
       max_recent_activity: 10,
       search_limit: 20,
     },


### PR DESCRIPTION
## Repro

Default FUSE mounts are accessible only to the mounting user. Any process running as a different uid gets EACCES on the mountpoint:

```
$ crm mount ~/crm
Mounted at /home/user/crm

$ sudo python3 -c "import os; print(os.lstat('/home/user/crm'))"
PermissionError: [Errno 13] Permission denied: '/home/user/crm'
```

This breaks consumers that enumerate the parent directory from a different process context — e.g. an e2b sandbox SDK calling `files.list('/home/user')` fails with `lstat /home/user/crm: permission denied` even though the mount is healthy from the user's own shell.

## Fix

Add a `--allow-other` CLI flag and matching `[mount].allow_other` config option. When set, the FUSE helper is invoked with `-o allow_other`, which lets any uid access the mount. The kernel still requires `user_allow_other` in `/etc/fuse.conf` when the mount is invoked by a non-root user; that's a deployment concern called out in the flag help text.

The macOS NFS path is unaffected — the option only applies to the Linux FUSE mount.

## Verification

```
# With --allow-other: root can read the mount
$ node dist/cli.js mount ~/crm --allow-other
Mounted at /home/user/crm (PID 8042)
$ sudo python3 -c "import os; print(os.lstat('/home/user/crm'))"
os.stat_result(st_mode=16877, st_ino=1, st_dev=44, ...)   ✓

# Without --allow-other: existing behavior, root gets EACCES
$ node dist/cli.js mount ~/crm
Mounted at /home/user/crm (PID 8140)
$ sudo python3 -c "import os; print(os.lstat('/home/user/crm'))"
PermissionError: [Errno 13] Permission denied: '/home/user/crm'
```

`bun run check-types` clean. `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)