### PR TITLE
fix: set PRAGMA busy_timeout=5000 to handle concurrent writers

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -94,6 +94,10 @@ export async function openDB(dbPath: string): Promise<DB> {
 
   await client.execute('PRAGMA journal_mode=WAL')
   await client.execute('PRAGMA foreign_keys=ON')
+  // Wait up to 5s for a busy lock instead of erroring immediately. SQLite
+  // is single-writer; without this, concurrent writes (e.g. parallel CLI
+  // invocations or daemon + CLI) hit SQLITE_BUSY and surface to the user.
+  await client.execute('PRAGMA busy_timeout=5000')
 
   return db
 }

--- a/test/db-busy-timeout.test.ts
+++ b/test/db-busy-timeout.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+
+import { createTestContext } from './helpers.ts'
+
+/**
+ * `PRAGMA busy_timeout` makes concurrent writers wait for the SQLite write
+ * lock instead of immediately erroring. Without it, parallel `crm contact
+ * add` calls return `SQLITE_BUSY: database is locked` under load.
+ */
+describe('SQLite busy timeout', () => {
+  test('parallel contact adds all succeed under contention', async () => {
+    const ctx = createTestContext()
+    // Empirically: N=20 doesn't reliably contend on this machine, but
+    // N=40 produces ~4 SQLITE_BUSY failures consistently when the
+    // busy_timeout PRAGMA isn't set.
+    const N = 40
+    const procs = Array.from({ length: N }, (_, i) =>
+      Bun.spawn(
+        [
+          'bun',
+          'run',
+          join(import.meta.dir, '..', 'src', 'cli.ts'),
+          '--db',
+          ctx.dbPath,
+          '--config',
+          ctx.configPath,
+          'contact',
+          'add',
+          '--name',
+          `User ${i}`,
+          '--email',
+          `u${i}@busy.test`,
+        ],
+        { stdout: 'pipe', stderr: 'pipe' },
+      ),
+    )
+    const results = await Promise.all(
+      procs.map(async (p) => ({
+        exitCode: await p.exited,
+        stderr: await new Response(p.stderr).text(),
+      })),
+    )
+    const failures = results.filter((r) => r.exitCode !== 0)
+    if (failures.length > 0) {
+      // Surface the first failure so the test output is actionable.
+      throw new Error(
+        `${failures.length}/${N} parallel adds failed; first stderr: ${failures[0].stderr}`,
+      )
+    }
+
+    const list = ctx.runJSON<unknown[]>('contact', 'list', '--format', 'json')
+    expect(list).toHaveLength(N)
+  }, 30_000)
+})


### PR DESCRIPTION
## Repro

SQLite is single-writer. Without `busy_timeout`, parallel write calls under load surface `SQLITE_BUSY` directly:

```
DrizzleQueryError: Failed query: insert into "contacts" ...
cause: SqliteError: database is locked
```

Easy to reproduce — 30 parallel `crm contact add` via `xargs -P10` produces ~2/30 failures consistently. Same pattern hits an agent that batches writes or has a daemon + CLI running concurrently against the same DB.

## Fix

Set `PRAGMA busy_timeout=5000` in `openDB`. SQLite handles retry/wait internally; concurrent writers block on the lock for up to 5s instead of erroring immediately. 5s is enough to ride out any realistic burst.

## Test

Added `test/db-busy-timeout.test.ts`: spawns 40 parallel `crm contact add` processes and asserts all 40 succeed with the contact list ending up at length 40.

- Without the PRAGMA: 4–6 failures in the run, test fails.
- With the PRAGMA: 0 failures, test passes.

Verified by toggling the PRAGMA off and rerunning. `bun run check-types` clean. `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)